### PR TITLE
moving minion and hero data into player model

### DIFF
--- a/src/main/java/com/hearthsim/Game.java
+++ b/src/main/java/com/hearthsim/Game.java
@@ -54,22 +54,24 @@ public class Game {
 		curPlayer_ = 0;
 
 		//the first player draws 3 cards
-		boardModel_.placeCard_hand_p0(0);
-		boardModel_.placeCard_hand_p0(1);
-		boardModel_.placeCard_hand_p0(2);
+		boardModel_.placeCardHandCurrentPlayer(0);
+		boardModel_.placeCardHandCurrentPlayer(1);
+		boardModel_.placeCardHandCurrentPlayer(2);
 		boardModel_.setDeckPos_p0(3);
 
 		//the second player draws 4 cards
-		boardModel_.placeCard_hand_p1(0);
-		boardModel_.placeCard_hand_p1(1);
-		boardModel_.placeCard_hand_p1(2);
-		boardModel_.placeCard_hand_p1(3);
-		boardModel_.placeCard_hand_p1(new TheCoin());
+		boardModel_.placeCardHandWaitingPlayer(0);
+		boardModel_.placeCardHandWaitingPlayer(1);
+		boardModel_.placeCardHandWaitingPlayer(2);
+		boardModel_.placeCardHandWaitingPlayer(3);
+		boardModel_.placeCardHandWaitingPlayer(new TheCoin());
 		boardModel_.setDeckPos_p1(4);
 		
 		GameRecord record = new GameSimpleRecord();
-		record.put(0, s0_, (BoardModel) boardModel_.deepCopy());
-		record.put(0, s1_, (BoardModel) boardModel_.flipPlayers().deepCopy());
+
+
+		record.put(0, boardModel_.getCurrentPlayer(), (BoardModel) boardModel_.deepCopy());
+		record.put(0, boardModel_.getWaitingPlayer(), (BoardModel) boardModel_.flipPlayers().deepCopy());
 
         GameResult gameResult;
         for (int turnCount = 0; turnCount < maxTurns_; ++turnCount) {
@@ -107,7 +109,7 @@ public class Game {
         boardModel_ = playAITurn(turnCount, boardModel_, ai);
         endTurn(boardModel_);
 
-        record.put(turnCount + 1, s0_, (BoardModel) boardModel_.deepCopy());
+        record.put(turnCount + 1, boardModel_.getCurrentPlayer(), (BoardModel) boardModel_.deepCopy());
 
         gameResult = checkGameOver(turnCount, record);
         if (gameResult != null) return gameResult;
@@ -118,9 +120,9 @@ public class Game {
     }
 
     public GameResult checkGameOver(int turnCount, GameRecord record){
-        if (!boardModel_.isAlive_p0()) {
+        if (!boardModel_.isAlive(boardModel_.getCurrentPlayer())) {
             return new GameResult(s0_, s1_, turnCount + 1, record);
-        } else if (!boardModel_.isAlive_p1()) {
+        } else if (!boardModel_.isAlive(boardModel_.getWaitingPlayer())) {
             return new GameResult(s0_, s0_, turnCount + 1, record);
         }
 
@@ -136,10 +138,10 @@ public class Game {
             //fatigue
             byte fatigueDamage = board.getFatigueDamage_p0();
             board.setFatigueDamage_p0((byte)(fatigueDamage + 1));
-            board.getHero_p0().setHealth((byte)(board.getHero_p0().getHealth() - fatigueDamage));
+            board.getCurrentPlayerHero().setHealth((byte)(board.getCurrentPlayerHero().getHealth() - fatigueDamage));
         } else {
             board.setDeckPos_p0(board.getDeckPos_p0() + 1);
-            board.placeCard_hand_p0(newCard);
+            board.placeCardHandCurrentPlayer(newCard);
         }
         if (board.getMana_p0() < 10)
             board.addMaxMana_p0(1);

--- a/src/main/java/com/hearthsim/card/minion/Hero.java
+++ b/src/main/java/com/hearthsim/card/minion/Hero.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.factory.BoardStateFactoryBase;
 import com.hearthsim.util.tree.HearthTreeNode;
@@ -83,18 +84,16 @@ public class Hero extends Minion {
 	 * 
 	 * A hero can only attack if it has a temporary buff, such as weapons
 	 * 
-	 * @param targetMinionPlayerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param targetMinion The target minion
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param targetMinionPlayerModel
+     * @param targetMinion The target minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode attack(
-			int targetMinionPlayerIndex,
+			PlayerModel targetMinionPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -118,7 +117,7 @@ public class Hero extends Minion {
 		}
 		
 		
-		HearthTreeNode toRet = super.attack(targetMinionPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.attack(targetMinionPlayerModel, targetMinion, boardState, deckPlayer0, deckPlayer1);
 
         if (toRet != null && this.weaponCharge_ > 0) {
             this.weaponCharge_ -= 1;
@@ -130,35 +129,34 @@ public class Hero extends Minion {
 	}
 	
 	@Override
-    public boolean canBeUsedOn(int playerIndex, Minion minioin) {
+    public boolean canBeUsedOn(PlayerModel playerModel, Minion minioin, BoardModel boardModel) {
 		if (hasBeenUsed_) 
 			return false;
 		return true;
     }
 
 	public final HearthTreeNode useHeroAbility(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSException
 	{
-		return this.useHeroAbility(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, false);
+		return this.useHeroAbility(targetPlayerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, false);
 	}
 	/**
 	 * Use the hero ability on a given target
 	 * 
-	 * @param targetPlayerIndex The player index of the target minion
-	 * @param targetMinion The target minion
-	 * @param boardState
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param targetMinion The target minion
+     * @param boardState
+     * @param deckPlayer0 The deck of player0
+     * @return
 	 */
 	public final HearthTreeNode useHeroAbility(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -169,7 +167,7 @@ public class Hero extends Minion {
 		if (boardState.data_.getMana_p0() < HERO_ABILITY_COST)
 			return null;
 		
-		HearthTreeNode toRet = this.useHeroAbility_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = this.useHeroAbility_core(targetPlayerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			toRet = BoardStateFactoryBase.handleDeadMinions(toRet, deckPlayer0, deckPlayer1);
 		}
@@ -177,7 +175,7 @@ public class Hero extends Minion {
 	}
 	
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -194,20 +192,18 @@ public class Hero extends Minion {
 	 * Overridden from Minion.  Need to handle armor.
 	 * 
 	 * @param damage The amount of damage to take
-	 * @param attackerPlayerIndex The player index of the attacker.  This is needed to do things like +spell damage.
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * @param isSpellDamage 
-	 * 
-	 * @throws HSInvalidPlayerIndexException
+	 * @param attackPlayerModel The player index of the attacker.  This is needed to do things like +spell damage.
+	 * @param thisPlayerModel
+     *@param boardState
+     * @param deckPlayer0 The deck of player0
+     * @param isSpellDamage
+*    @throws HSInvalidPlayerIndexException
 	 */
 	@Override
 	public HearthTreeNode takeDamage(
 			byte damage,
-			int attackerPlayerIndex,
-			int thisPlayerIndex,
+			PlayerModel attackPlayerModel,
+			PlayerModel thisPlayerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0, 
 			Deck deckPlayer1,
@@ -219,7 +215,7 @@ public class Hero extends Minion {
 		byte damageRemaining = (byte)(damage - armor_);
 		if (damageRemaining > 0) {
 			armor_ = 0;
-			toRet = super.takeDamage(damageRemaining, attackerPlayerIndex, thisPlayerIndex, toRet, deckPlayer0, deckPlayer1, isSpellDamage, handleMinionDeath);
+			toRet = super.takeDamage(damageRemaining, attackPlayerModel, thisPlayerModel, toRet, deckPlayer0, deckPlayer1, isSpellDamage, handleMinionDeath);
 		} else {
 			armor_ = (byte)(armor_ - damage);
 		}
@@ -234,7 +230,7 @@ public class Hero extends Minion {
 	 * temporary buffs that it has.
 	 */
 	@Override
-	public BoardModel endTurn(int thisMinionPlayerIndex, BoardModel boardModel, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+	public BoardModel endTurn(PlayerModel thisMinionPlayerIndex, BoardModel boardModel, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
 		this.extraAttackUntilTurnEnd_ = 0;
 		return boardModel;
 	}

--- a/src/main/java/com/hearthsim/card/minion/MinionWithEnrage.java
+++ b/src/main/java/com/hearthsim/card/minion/MinionWithEnrage.java
@@ -5,6 +5,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public abstract class MinionWithEnrage extends Minion {
@@ -66,27 +67,25 @@ public abstract class MinionWithEnrage extends Minion {
 	 * Override for enrage
 	 * 
 	 * @param damage The amount of damage to take
-	 * @param attackerPlayerIndex The player index of the attacker.  This is needed to do things like +spell damage.
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * @param isSpellDamage True if this is a spell damage
-	 * 
-	 * @throws HSInvalidPlayerIndexException
+	 * @param attackPlayerModel The player index of the attacker.  This is needed to do things like +spell damage.
+	 * @param thisPlayerModel
+     *@param boardState
+     * @param deckPlayer0 The deck of player0
+     * @param isSpellDamage True if this is a spell damage
+*    @throws HSInvalidPlayerIndexException
 	 */
 	@Override
 	public HearthTreeNode takeDamage(
 			byte damage,
-			int attackerPlayerIndex,
-			int thisPlayerIndex,
+			PlayerModel attackPlayerModel,
+			PlayerModel thisPlayerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0, 
 			Deck deckPlayer1,
 			boolean isSpellDamage,
 			boolean handleMinionDeath)
 		throws HSException
-	{		HearthTreeNode toRet = super.takeDamage(damage, attackerPlayerIndex, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1, isSpellDamage, handleMinionDeath);
+	{		HearthTreeNode toRet = super.takeDamage(damage, attackPlayerModel, thisPlayerModel, boardState, deckPlayer0, deckPlayer1, isSpellDamage, handleMinionDeath);
 		this.enrageCheck();
 		return toRet;
 	}
@@ -97,16 +96,13 @@ public abstract class MinionWithEnrage extends Minion {
 	 * Always use this function to heal minions
 	 * 
 	 * @param healAmount The amount of healing to take
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @throws HSInvalidPlayerIndexException
+	 * @param thisPlayerModel
+     *@param boardState
+     * @param deckPlayer0 The deck of player0   @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode takeHeal(byte healAmount, int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
-		HearthTreeNode toRet = super.takeHeal(healAmount, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+	public HearthTreeNode takeHeal(byte healAmount, PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+		HearthTreeNode toRet = super.takeHeal(healAmount, thisPlayerModel, boardState, deckPlayer0, deckPlayer1);
 		this.enrageCheck();
 		return toRet;
 	}
@@ -116,16 +112,15 @@ public abstract class MinionWithEnrage extends Minion {
 	 * 
 	 * Always use this function to "silence" minions
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @param deckPlayer0 The deck of player0
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode silenced(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
-		HearthTreeNode toRet = super.silenced(thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+	public HearthTreeNode silenced(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+		HearthTreeNode toRet = super.silenced(thisPlayerModel, boardState, deckPlayer0, deckPlayer1);
 		if (enraged_)
 			this.pacify();
 		return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/Abomination.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Abomination.java
@@ -165,13 +165,13 @@ public class Abomination extends Minion {
 //		
 //		HearthTreeNode toRet = super.destroyed(thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
 //		if (!silenced_) {
-//			toRet = toRet.data_.getHero_p1().takeDamage((byte)2, thisPlayerIndex, 1, toRet, deckPlayer0, deckPlayer1, false, false);
-//			for(Minion minion : toRet.data_.getMinions_p1()) {
+//			toRet = toRet.data_.getWaitingPlayerHero().takeDamage((byte)2, thisPlayerIndex, 1, toRet, deckPlayer0, deckPlayer1, false, false);
+//			for(Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
 //				toRet = minion.takeDamage((byte)2, thisPlayerIndex, 1, toRet, deckPlayer0, deckPlayer1, false, false);
 //			}
-//			toRet = toRet.data_.getHero_p0().takeDamage((byte)2, thisPlayerIndex, 0, toRet, deckPlayer0, deckPlayer1, false, false);
-//			for(Minion minion : toRet.data_.getMinions_p0()) {
-//				toRet = minion.takeDamage((byte)2, thisPlayerIndex, 0, toRet, deckPlayer0, deckPlayer1, false, false);
+//			toRet = toRet.data_.getCurrentPlayerHero().takeDamage((byte)2, thisPlayerIndex, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, false, false);
+//			for(Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
+//				toRet = minion.takeDamage((byte)2, thisPlayerIndex, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, false, false);
 //			}
 //		}
 //		return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/AbusiveSergeant.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/AbusiveSergeant.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class AbusiveSergeant extends Minion {
@@ -160,17 +161,17 @@ public class AbusiveSergeant extends Minion {
 	 * 
 	 * Battlecry: Give a minion +2 attack this turn
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     *
+     * @param targetPlayer
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * return The boardState is manipulated and returned
 	 */
 
 	@Override
 	public HearthTreeNode useOn(
-			int targetPlayerIndex,
+			PlayerModel  targetPlayer,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -179,20 +180,20 @@ public class AbusiveSergeant extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.useOn(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.useOn(targetPlayer, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			for (int index = 0; index < boardState.data_.getNumMinions_p0(); ++index) {
-				if (index != toRet.data_.getMinions_p0().indexOf(this)) {
+			for (int index = 0; index < boardState.data_.getCurrentPlayer().getNumMinions(); ++index) {
+				if (index != toRet.data_.getCurrentPlayer().getMinions().indexOf(this)) {
 					HearthTreeNode newState = boardState.addChild(new HearthTreeNode((BoardModel)boardState.data_.deepCopy()));
-					newState.data_.getMinion_p0(index).setExtraAttackUntilTurnEnd(((byte)(newState.data_.getMinion_p0(index).getExtraAttackUntilTurnEnd() + 2)));
+					newState.data_.getCurrentPlayer().getMinions().get(index).setExtraAttackUntilTurnEnd(((byte)(newState.data_.getCurrentPlayer().getMinions().get(index).getExtraAttackUntilTurnEnd() + 2)));
 				}
 			}
 			
-			for (int index = 0; index < boardState.data_.getNumMinions_p1(); ++index) {
-				if (index != toRet.data_.getMinions_p1().indexOf(this)) {
+			for (int index = 0; index < boardState.data_.getWaitingPlayer().getNumMinions(); ++index) {
+				if (index != toRet.data_.getWaitingPlayer().getMinions().indexOf(this)) {
 					HearthTreeNode newState = boardState.addChild(new HearthTreeNode((BoardModel)boardState.data_.deepCopy()));
-					newState.data_.getMinion_p1(index).setExtraAttackUntilTurnEnd(((byte)(newState.data_.getMinion_p1(index).getExtraAttackUntilTurnEnd() + 2)));
+					newState.data_.getWaitingPlayer().getMinions().get(index).setExtraAttackUntilTurnEnd(((byte)(newState.data_.getWaitingPlayer().getMinions().get(index).getExtraAttackUntilTurnEnd() + 2)));
 				}
 			}
 			return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/AcidicSwampOoze.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/AcidicSwampOoze.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class AcidicSwampOoze extends Minion {
@@ -159,16 +160,15 @@ public class AcidicSwampOoze extends Minion {
 	 * 
 	 * Battlecry: Destroy your opponent's weapon
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -182,18 +182,18 @@ public class AcidicSwampOoze extends Minion {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
-		if (boardState.data_.getHero_p1().getWeaponCharge() > 0) {
-			boardState.data_.getHero_p1().setWeaponCharge((byte)0);
-			boardState.data_.getHero_p1().setAttack((byte)0);
+		if (boardState.data_.getWaitingPlayerHero().getWeaponCharge() > 0) {
+			boardState.data_.getWaitingPlayerHero().setWeaponCharge((byte)0);
+			boardState.data_.getWaitingPlayerHero().setAttack((byte)0);
 		}
 		
-		return super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		return super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 	}
 
 }

--- a/src/main/java/com/hearthsim/card/minion/concrete/AcolyteOfPain.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/AcolyteOfPain.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -161,19 +162,16 @@ public class AcolyteOfPain extends Minion {
 	 * Draw a card whenever this minion takes damage
 	 * 
 	 * @param damage The amount of damage to take
-	 * @param attackerPlayerIndex The player index of the attacker.  This is needed to do things like +spell damage.
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param thisMinionIndex The minion index of this minion
-	 * @param boardState 
-	 * @param deck
-	 * @param isSpellDamage True if this is a spell damage
-	 * @throws HSException
+	 * @param attackPlayerModel The player index of the attacker.  This is needed to do things like +spell damage.
+	 * @param thisPlayerModel
+     *@param boardState
+     * @param isSpellDamage True if this is a spell damage   @throws HSException
 	 */
 	@Override
 	public HearthTreeNode takeDamage(
 			byte damage,
-			int attackerPlayerIndex,
-			int thisPlayerIndex,
+			PlayerModel attackPlayerModel,
+			PlayerModel thisPlayerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0, 
 			Deck deckPlayer1,
@@ -182,8 +180,8 @@ public class AcolyteOfPain extends Minion {
 		throws HSException
 	{
 		if (!divineShield_) {
-			HearthTreeNode toRet = super.takeDamage(damage, attackerPlayerIndex, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1, isSpellDamage, handleMinionDeath);
-			if (damage > 0 && thisPlayerIndex == 0) {
+			HearthTreeNode toRet = super.takeDamage(damage, attackPlayerModel, thisPlayerModel, boardState, deckPlayer0, deckPlayer1, isSpellDamage, handleMinionDeath);
+			if (damage > 0 && thisPlayerModel == boardState.data_.getCurrentPlayer()) {
 				if (toRet instanceof CardDrawNode) {
 					((CardDrawNode) toRet).addNumCardsToDraw(1);
 				} else {
@@ -191,7 +189,7 @@ public class AcolyteOfPain extends Minion {
 				}
 			} else if (damage > 0) {
 				//This minion is an enemy minion.  Let's draw a card for the enemy.  No need to use a StopNode for enemy card draws.
-				toRet.data_.drawCardFromDeck_p1(deckPlayer1, 1);
+				toRet.data_.drawCardFromWaitingPlayerDeck(deckPlayer1, 1);
 			}
 			return toRet;
 		} else {

--- a/src/main/java/com/hearthsim/card/minion/concrete/AldorPeacekeeper.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/AldorPeacekeeper.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class AldorPeacekeeper extends Minion {
@@ -160,16 +161,15 @@ public class AldorPeacekeeper extends Minion {
 	 * 
 	 * Battlecry: Change an enemy minion's attack to 1
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,13 +178,13 @@ public class AldorPeacekeeper extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			for (int index = 0; index < toRet.data_.getNumMinions_p1(); ++index) {
-				if (index != toRet.data_.getMinions_p1().indexOf(this)) {
+			for (int index = 0; index < toRet.data_.getWaitingPlayer().getNumMinions(); ++index) {
+				if (index != toRet.data_.getWaitingPlayer().getMinions().indexOf(this)) {
 					HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-					newState.data_.getMinion_p1(index).setAttack((byte)1);
+					newState.data_.getWaitingPlayer().getMinions().get(index).setAttack((byte)1);
 				}
 			}
 			return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/Alexstrasza.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Alexstrasza.java
@@ -7,6 +7,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Alexstrasza extends Dragon {
@@ -161,16 +162,15 @@ public class Alexstrasza extends Dragon {
 	 * 
 	 * Battlecry: Set a hero's remaining health to 15
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -179,16 +179,16 @@ public class Alexstrasza extends Dragon {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
 			{
 				HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-				newState.data_.getHero_p0().setHealth((byte)15);
+				newState.data_.getCurrentPlayerHero().setHealth((byte)15);
 			}
 			{
 				HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-				newState.data_.getHero_p1().setHealth((byte)15);
+				newState.data_.getWaitingPlayerHero().setHealth((byte)15);
 			}
 			return toRet;
 		} else {

--- a/src/main/java/com/hearthsim/card/minion/concrete/AncientOfLore.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/AncientOfLore.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -161,16 +162,15 @@ public class AncientOfLore extends Minion {
 	 * 
 	 * Choose one: Draw 2 cards; or Restore 5 health
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,25 +178,25 @@ public class AncientOfLore extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			int thisMinionIndex = toRet.data_.getMinions_p0().indexOf(this);
+			int thisMinionIndex = toRet.data_.getCurrentPlayer().getMinions().indexOf(this);
 			{
 				HearthTreeNode newState = toRet.addChild(new CardDrawNode(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()), 2));
 			}
 			{
 				{
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-					newState = newState.data_.getHero_p0().takeHeal(HEAL_AMOUNT, 0, newState, deckPlayer0, deckPlayer1);
+					newState = newState.data_.getCurrentPlayerHero().takeHeal(HEAL_AMOUNT, newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
 				
 				{
-					for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
+					for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
 						if (index != thisMinionIndex) {
 							HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-							newState = newState.data_.getMinion_p0(index).takeHeal(HEAL_AMOUNT, 0, newState, deckPlayer0, deckPlayer1);
+							newState = newState.data_.getCurrentPlayer().getMinions().get(index).takeHeal(HEAL_AMOUNT, newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1);
 							toRet.addChild(newState);
 						}
 					}
@@ -204,14 +204,14 @@ public class AncientOfLore extends Minion {
 
 				{
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-					newState = newState.data_.getHero_p1().takeHeal(HEAL_AMOUNT, 1, newState, deckPlayer0, deckPlayer1);
+					newState = newState.data_.getWaitingPlayerHero().takeHeal(HEAL_AMOUNT, newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
 				
 				{
-					for (int index = 0; index < toRet.data_.getNumMinions_p1(); ++index) {
+					for (int index = 0; index < toRet.data_.getWaitingPlayer().getNumMinions(); ++index) {
 						HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-						newState = newState.data_.getMinion_p1(index).takeHeal(HEAL_AMOUNT, 1, newState, deckPlayer0, deckPlayer1);
+						newState = newState.data_.getWaitingPlayer().getMinions().get(index).takeHeal(HEAL_AMOUNT, newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1);
 						toRet.addChild(newState);
 					}
 				}

--- a/src/main/java/com/hearthsim/card/minion/concrete/AncientOfWar.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/AncientOfWar.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class AncientOfWar extends Minion {
@@ -158,16 +159,15 @@ public class AncientOfWar extends Minion {
 	 * 
 	 * Choose one: +5 health and Taunt; or +5 Attack
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -175,19 +175,19 @@ public class AncientOfWar extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			int thisMinionIndex = toRet.data_.getMinions_p0().indexOf(this);
+			int thisMinionIndex = toRet.data_.getCurrentPlayer().getMinions().indexOf(this);
 			{
 				HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-				newState.data_.getMinion_p0(thisMinionIndex).setTaunt(true);
-				newState.data_.getMinion_p0(thisMinionIndex).setMaxHealth((byte)10);
-				newState.data_.getMinion_p0(thisMinionIndex).setHealth((byte)10);
+				newState.data_.getCurrentPlayer().getMinions().get(thisMinionIndex).setTaunt(true);
+				newState.data_.getCurrentPlayer().getMinions().get(thisMinionIndex).setMaxHealth((byte)10);
+				newState.data_.getCurrentPlayer().getMinions().get(thisMinionIndex).setHealth((byte)10);
 			}
 			{
 				HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-				newState.data_.getMinion_p0(thisMinionIndex).setAttack((byte)10);
+				newState.data_.getCurrentPlayer().getMinions().get(thisMinionIndex).setAttack((byte)10);
 			}
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/ArcaneGolem.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/ArcaneGolem.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class ArcaneGolem extends Minion {
@@ -159,16 +160,15 @@ public class ArcaneGolem extends Minion {
 	 * 
 	 * Battlecry: Give your opponent a Mana Crystal
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -177,7 +177,7 @@ public class ArcaneGolem extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
 			toRet.data_.addMana_p1(1);

--- a/src/main/java/com/hearthsim/card/minion/concrete/ArchmageAntonidas.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/ArchmageAntonidas.java
@@ -8,6 +8,7 @@ import com.hearthsim.card.spellcard.concrete.Fireball;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class ArchmageAntonidas extends Minion {
@@ -162,32 +163,31 @@ public class ArchmageAntonidas extends Minion {
 	 * 
 	 * When you cast a spell, put a Fireball spell into your hand
 	 * 
-	 * @param thisCardPlayerIndex The player index of the card receiving the event
-	 * @param cardUserPlayerIndex The player index of the player that used the card
-	 * @param usedCard The card that was used
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer1 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 * @param thisCardPlayerModel The player index of the card receiving the event
+	 * @param cardUserPlayerModel
+     *@param usedCard The card that was used
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0
+     * @param deckPlayer1 The deck of player1
+*     @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode otherCardUsedEvent(
-			int thisCardPlayerIndex,
-			int cardUserPlayerIndex,
+			PlayerModel thisCardPlayerModel,
+			PlayerModel cardUserPlayerModel,
 			Card usedCard,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.otherCardUsedEvent(thisCardPlayerIndex, cardUserPlayerIndex, usedCard, boardState, deckPlayer0, deckPlayer1);
-		if (thisCardPlayerIndex != 0)
+		HearthTreeNode toRet = super.otherCardUsedEvent(thisCardPlayerModel, cardUserPlayerModel, usedCard, boardState, deckPlayer0, deckPlayer1);
+		if (thisCardPlayerModel != boardState.data_.getCurrentPlayer())
 			return toRet;
 		if (isInHand_)
 			return toRet;
-        if (usedCard instanceof SpellCard && toRet.data_.getNumCards_hand_p0() < 10) {
-            toRet.data_.placeCard_hand_p0(new Fireball());
+        if (usedCard instanceof SpellCard && toRet.data_.getNumCardsHandCurrentPlayer() < 10) {
+            toRet.data_.placeCardHandCurrentPlayer(new Fireball());
         }
         return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/ArgentProtector.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/ArgentProtector.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class ArgentProtector extends Minion {
@@ -160,16 +161,15 @@ public class ArgentProtector extends Minion {
 	 * 
 	 * Battlecry: Give a friendly minion Divine Shield
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,13 +178,13 @@ public class ArgentProtector extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
-				if (index != toRet.data_.getMinions_p0().indexOf(this)) {
+			for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
+				if (index != toRet.data_.getCurrentPlayer().getMinions().indexOf(this)) {
 					HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-					newState.data_.getMinion_p0(index).setDivineShield(true);
+					newState.data_.getCurrentPlayer().getMinions().get(index).setDivineShield(true);
 				}
 			}
 			return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/Armorsmith.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Armorsmith.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Armorsmith extends Minion {
@@ -158,27 +159,25 @@ public class Armorsmith extends Minion {
 	 * 
 	 * Whenever a friendly minion takes damage, gain 1 Armor
 	 * 
-	 * @param thisMinionPlayerIndex The index of the damaged minion's player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param damagedPlayerIndex The player index of the damaged minion.
-	 * @param damagedMinion The damaged minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param damagedPlayerModel
+     *@param damagedMinion The damaged minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionDamagedEvent(
-			int thisMinionPlayerIndex,
-			int damagedPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel damagedPlayerModel,
 			Minion damagedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		HearthTreeNode toRet = super.minionDamagedEvent(thisMinionPlayerIndex, damagedPlayerIndex, damagedMinion, boardState, deckPlayer0, deckPlayer1);
-		if (thisMinionPlayerIndex == damagedPlayerIndex) {
-			Hero hero = toRet.data_.getHero(thisMinionPlayerIndex);
+		HearthTreeNode toRet = super.minionDamagedEvent(thisMinionPlayerModel, damagedPlayerModel, damagedMinion, boardState, deckPlayer0, deckPlayer1);
+		if (thisMinionPlayerModel == damagedPlayerModel) {
+			Hero hero = toRet.data_.getHero(thisMinionPlayerModel);
 			hero.setArmor((byte)(hero.getArmor() + 1));
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/AzureDrake.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/AzureDrake.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -161,16 +162,15 @@ public class AzureDrake extends Minion {
 	 * 
 	 * Battlecry: Draw one card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -184,13 +184,13 @@ public class AzureDrake extends Minion {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet instanceof CardDrawNode)
 			((CardDrawNode) toRet).addNumCardsToDraw(1);
 		else

--- a/src/main/java/com/hearthsim/card/minion/concrete/BigGameHunter.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/BigGameHunter.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.factory.BoardStateFactoryBase;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -161,16 +162,15 @@ public class BigGameHunter extends Minion {
 	 * 
 	 * Battlecry: Destroy a minion with an Attack of 7 or more
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,22 +178,22 @@ public class BigGameHunter extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			int thisMinionIndex = toRet.data_.getMinions_p0().indexOf(this);
-			for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
-				if (toRet.data_.getMinion_p0(index).getTotalAttack() >= 7 && index != thisMinionIndex) {
+			int thisMinionIndex = toRet.data_.getCurrentPlayer().getMinions().indexOf(this);
+			for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
+				if (toRet.data_.getCurrentPlayer().getMinions().get(index).getTotalAttack() >= 7 && index != thisMinionIndex) {
 					HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-					Minion battlecryTarget = newState.data_.getMinion_p0(index);
+					Minion battlecryTarget = newState.data_.getCurrentPlayer().getMinions().get(index);
 					battlecryTarget.setHealth((byte)-99);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 				}
 			}
-			for (int index = 0; index < toRet.data_.getNumMinions_p1(); ++index) {
-				if (toRet.data_.getMinion_p1(index).getTotalAttack() >= 7) {
+			for (int index = 0; index < toRet.data_.getWaitingPlayer().getNumMinions(); ++index) {
+				if (toRet.data_.getWaitingPlayer().getMinions().get(index).getTotalAttack() >= 7) {
 					HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-					Minion battlecryTarget = newState.data_.getMinion_p1(index);
+					Minion battlecryTarget = newState.data_.getWaitingPlayer().getMinions().get(index);
 					battlecryTarget.setHealth((byte)-99);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 				}

--- a/src/main/java/com/hearthsim/card/minion/concrete/ColdlightOracle.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/ColdlightOracle.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Murloc;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -163,16 +164,15 @@ public class ColdlightOracle extends Murloc {
 	 * 
 	 * Battlecry: Each player draws 2 cards
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -180,14 +180,14 @@ public class ColdlightOracle extends Murloc {
 			boolean singleRealizationOnly)
 		throws HSException
 	{		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			if (toRet instanceof CardDrawNode)
 				((CardDrawNode) toRet).addNumCardsToDraw(2);
 			else
 				toRet = new CardDrawNode(toRet, 2); //draw two cards
 			
-			toRet.data_.drawCardFromDeck_p1(deckPlayer1, 2);
+			toRet.data_.drawCardFromWaitingPlayerDeck(deckPlayer1, 2);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/CrazedAlchemist.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/CrazedAlchemist.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.factory.BoardStateFactoryBase;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -163,16 +164,15 @@ public class CrazedAlchemist extends Minion {
 	 * 
 	 * Battlecry: Swap the attack and Health of a minion
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -181,14 +181,14 @@ public class CrazedAlchemist extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			int thisMinionIndex = toRet.data_.getMinions_p0().indexOf(this);
-			for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
+			int thisMinionIndex = toRet.data_.getCurrentPlayer().getMinions().indexOf(this);
+			for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
 				if (index != thisMinionIndex) {
 					HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-					Minion battlecryTarget = newState.data_.getMinion_p0(index);
+					Minion battlecryTarget = newState.data_.getCurrentPlayer().getMinions().get(index);
 					byte newHealth = battlecryTarget.getTotalAttack();
 					byte newAttack = battlecryTarget.getTotalHealth();
 					battlecryTarget.setAttack(newAttack);
@@ -196,9 +196,9 @@ public class CrazedAlchemist extends Minion {
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 				}
 			}
-			for (int index = 0; index < toRet.data_.getNumMinions_p1(); ++index) {
+			for (int index = 0; index < toRet.data_.getWaitingPlayer().getNumMinions(); ++index) {
 				HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-				Minion battlecryTarget = newState.data_.getMinion_p1(index);
+				Minion battlecryTarget = newState.data_.getWaitingPlayer().getMinions().get(index);
 				byte newHealth = battlecryTarget.getTotalAttack();
 				byte newAttack = battlecryTarget.getTotalHealth();
 				battlecryTarget.setAttack(newAttack);

--- a/src/main/java/com/hearthsim/card/minion/concrete/CruelTaskmaster.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/CruelTaskmaster.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.factory.BoardStateFactoryBase;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -161,16 +162,15 @@ public class CruelTaskmaster extends Minion {
 	 * 
 	 * Battlecry: Deal 1 damage to a minion and give it +2 Attack
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -179,24 +179,24 @@ public class CruelTaskmaster extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			int thisMinionIndex = toRet.data_.getMinions_p0().indexOf(this);
-			for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
+			int thisMinionIndex = toRet.data_.getCurrentPlayer().getMinions().indexOf(this);
+			for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
 				if (index != thisMinionIndex) {
 					HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-					Minion battlecryTarget = newState.data_.getMinion_p0(index);
-					battlecryTarget.setAttack((byte)(newState.data_.getMinion_p0(index).getAttack() + 2));
-					newState = battlecryTarget.takeDamage((byte)1, 0, 0, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion battlecryTarget = newState.data_.getCurrentPlayer().getMinions().get(index);
+					battlecryTarget.setAttack((byte)(newState.data_.getCurrentPlayer().getMinions().get(index).getAttack() + 2));
+					newState = battlecryTarget.takeDamage((byte)1, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 				}
 			}
-			for (int index = 0; index < toRet.data_.getNumMinions_p1(); ++index) {
+			for (int index = 0; index < toRet.data_.getWaitingPlayer().getNumMinions(); ++index) {
 				HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-				Minion battlecryTarget = newState.data_.getMinion_p1(index);
-				battlecryTarget.setAttack((byte)(newState.data_.getMinion_p1(index).getAttack() + 2));
-				newState = battlecryTarget.takeDamage((byte)1, 0, 1, newState, deckPlayer0, deckPlayer1, false, true);
+				Minion battlecryTarget = newState.data_.getWaitingPlayer().getMinions().get(index);
+				battlecryTarget.setAttack((byte)(newState.data_.getWaitingPlayer().getMinions().get(index).getAttack() + 2));
+				newState = battlecryTarget.takeDamage((byte)1, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 				newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 			}
 			return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/DarkscaleHealer.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/DarkscaleHealer.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DarkscaleHealer extends Minion {
@@ -161,16 +162,15 @@ public class DarkscaleHealer extends Minion {
 	 * 
 	 * Battlecry: Heals friendly characters for 2
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -184,18 +184,18 @@ public class DarkscaleHealer extends Minion {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
 		HearthTreeNode toRet = boardState;
-		toRet = toRet.data_.getHero_p0().takeHeal((byte)2, 0, toRet, deckPlayer0, deckPlayer1);
-		for (Minion minion : toRet.data_.getMinions_p0()) {
-			toRet = minion.takeHeal((byte)2, 0, toRet, deckPlayer0, deckPlayer1);
+		toRet = toRet.data_.getCurrentPlayerHero().takeHeal((byte)2, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
+		for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
+			toRet = minion.takeHeal((byte)2, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
 		}
 		
-		return super.use_core(targetPlayerIndex, targetMinion, toRet, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		return super.use_core(playerModel, targetMinion, toRet, deckPlayer0, deckPlayer1, singleRealizationOnly);
 	}
 }

--- a/src/main/java/com/hearthsim/card/minion/concrete/DefenderOfArgus.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/DefenderOfArgus.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DefenderOfArgus extends Minion {
@@ -160,16 +161,15 @@ public class DefenderOfArgus extends Minion {
 	 * 
 	 * Battlecry: Give adjacent minions +1/+1 and Taunt
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -177,25 +177,25 @@ public class DefenderOfArgus extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			int thisMinionIndex = toRet.data_.getMinions(targetPlayerIndex).indexOf(this);
+			int thisMinionIndex = toRet.data_.getMinions(playerModel).indexOf(this);
 			if (thisMinionIndex == 0) {
-				Minion minionToBuff = toRet.data_.getMinion(targetPlayerIndex, 1);
+				Minion minionToBuff = toRet.data_.getMinion(playerModel, 1);
 				minionToBuff.setAttack((byte)(minionToBuff.getAttack() + 1));
 				minionToBuff.setHealth((byte)(minionToBuff.getHealth() + 1));
 				minionToBuff.setTaunt(true);
 			} else if (thisMinionIndex == 6) {
-				Minion minionToBuff = toRet.data_.getMinion(targetPlayerIndex, 5);
+				Minion minionToBuff = toRet.data_.getMinion(playerModel, 5);
 				minionToBuff.setAttack((byte)(minionToBuff.getAttack() + 1));
 				minionToBuff.setHealth((byte)(minionToBuff.getHealth() + 1));
 				minionToBuff.setTaunt(true);				
 			} else {
-				Minion minionToBuff0 = toRet.data_.getMinion(targetPlayerIndex, thisMinionIndex - 1);
+				Minion minionToBuff0 = toRet.data_.getMinion(playerModel, thisMinionIndex - 1);
 				minionToBuff0.setAttack((byte)(minionToBuff0.getAttack() + 1));
 				minionToBuff0.setHealth((byte)(minionToBuff0.getHealth() + 1));
 				minionToBuff0.setTaunt(true);				
-				Minion minionToBuff1 = toRet.data_.getMinion(targetPlayerIndex, thisMinionIndex + 1);
+				Minion minionToBuff1 = toRet.data_.getMinion(playerModel, thisMinionIndex + 1);
 				minionToBuff1.setAttack((byte)(minionToBuff1.getAttack() + 1));
 				minionToBuff1.setHealth((byte)(minionToBuff1.getHealth() + 1));
 				minionToBuff1.setTaunt(true);				

--- a/src/main/java/com/hearthsim/card/minion/concrete/DragonlingMechanic.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/DragonlingMechanic.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DragonlingMechanic extends Minion {
@@ -161,16 +162,15 @@ public class DragonlingMechanic extends Minion {
 	 * 
 	 * Battlecry: Summons a Mechanical Dragonling
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -184,17 +184,17 @@ public class DragonlingMechanic extends Minion {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
-		if (toRet != null && toRet.data_.getNumMinions_p0() < 7) {
+		if (toRet != null && toRet.data_.getCurrentPlayer().getNumMinions() < 7) {
 			Minion mdragon = new MechanicalDragonling();
-			mdragon.summonMinion(targetPlayerIndex, this, boardState, deckPlayer0, deckPlayer1, false);
+			mdragon.summonMinion(playerModel, this, boardState, deckPlayer0, deckPlayer1, false);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/DreadInfernal.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/DreadInfernal.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DreadInfernal extends Demon {
@@ -160,16 +161,15 @@ public class DreadInfernal extends Demon {
 	 * 
 	 * Battlecry: Deals 1 damage to all characters
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -183,23 +183,23 @@ public class DreadInfernal extends Demon {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
 		HearthTreeNode toRet = boardState;
-		toRet = toRet.data_.getHero_p0().takeDamage((byte)1, 0, 0, toRet, deckPlayer0, deckPlayer1, false, false);
-		for (Minion minion : toRet.data_.getMinions_p0()) {
-			toRet = minion.takeDamage((byte)1, 0, 0, boardState, deckPlayer0, deckPlayer1, false, false);
+		toRet = toRet.data_.getCurrentPlayerHero().takeDamage((byte)1, toRet.data_.getCurrentPlayer(), toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, false, false);
+		for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
+			toRet = minion.takeDamage((byte)1, boardState.data_.getCurrentPlayer(), boardState.data_.getCurrentPlayer(), boardState, deckPlayer0, deckPlayer1, false, false);
 		}
 		
-		toRet = toRet.data_.getHero_p1().takeDamage((byte)1, 0, 1, boardState, deckPlayer0, deckPlayer1, false, false);
-		for (Minion minion : toRet.data_.getMinions_p1()) {
-			toRet = minion.takeDamage((byte)1, 0, 1, boardState, deckPlayer0, deckPlayer1, false, false);
+		toRet = toRet.data_.getWaitingPlayerHero().takeDamage((byte)1, boardState.data_.getCurrentPlayer(), boardState.data_.getWaitingPlayer(), boardState, deckPlayer0, deckPlayer1, false, false);
+		for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+			toRet = minion.takeDamage((byte)1, boardState.data_.getCurrentPlayer(), boardState.data_.getWaitingPlayer(), boardState, deckPlayer0, deckPlayer1, false, false);
 		}
 		
-		return super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		return super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 	}
 }

--- a/src/main/java/com/hearthsim/card/minion/concrete/DustDevil.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/DustDevil.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DustDevil extends Minion {
@@ -158,16 +159,15 @@ public class DustDevil extends Minion {
 	 * 
 	 * Overload: 2
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -175,9 +175,9 @@ public class DustDevil extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet.data_.addOverload(targetPlayerIndex, (byte)2);
+			toRet.data_.addOverload(playerModel, (byte)2);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/EarthElemental.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/EarthElemental.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class EarthElemental extends Minion {
@@ -158,16 +159,15 @@ public class EarthElemental extends Minion {
 	 * 
 	 * Overload: 3
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -175,9 +175,9 @@ public class EarthElemental extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet.data_.addOverload(targetPlayerIndex, (byte)3);
+			toRet.data_.addOverload(playerModel, (byte)3);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/ElvenArcher.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/ElvenArcher.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.factory.BoardStateFactoryBase;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -163,16 +164,15 @@ public class ElvenArcher extends Minion {
 	 * 
 	 * Battlecry: Deal 1 damage to a chosen target
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -180,22 +180,22 @@ public class ElvenArcher extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{	
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-				newState = newState.data_.getHero_p0().takeDamage((byte)1, 0, 0, newState, deckPlayer0, deckPlayer1, false, false);
+				newState = newState.data_.getCurrentPlayerHero().takeDamage((byte)1, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, false);
 				toRet.addChild(newState);
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p0(); ++index) {
-					if (boardState.data_.getMinion_p0(index) == this)
+				for (int index = 0; index < boardState.data_.getCurrentPlayer().getNumMinions(); ++index) {
+					if (boardState.data_.getCurrentPlayer().getMinions().get(index) == this)
 						continue;
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p0(index);
-					newState = minion.takeDamage((byte)1, 0, 0, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion minion = newState.data_.getCurrentPlayer().getMinions().get(index);
+					newState = minion.takeDamage((byte)1, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
@@ -203,15 +203,15 @@ public class ElvenArcher extends Minion {
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-				newState = newState.data_.getHero_p1().takeDamage((byte)1, 0, 1, newState, deckPlayer0, deckPlayer1, false, false);
+				newState = newState.data_.getWaitingPlayerHero().takeDamage((byte)1, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, false);
 				toRet.addChild(newState);
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p1(); ++index) {		
+				for (int index = 0; index < boardState.data_.getWaitingPlayer().getNumMinions(); ++index) {
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p1(index);
-					newState = minion.takeDamage((byte)1, 0, 1, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion minion = newState.data_.getWaitingPlayer().getMinions().get(index);
+					newState = minion.takeDamage((byte)1, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}

--- a/src/main/java/com/hearthsim/card/minion/concrete/FireElemental.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/FireElemental.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.factory.BoardStateFactoryBase;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -164,16 +165,15 @@ public class FireElemental extends Minion {
 	 * 
 	 * Battlecry: Deal 3 damage to a chosen target
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -181,22 +181,22 @@ public class FireElemental extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-				newState = newState.data_.getHero_p0().takeDamage(BATTLECRY_DAMAGE, 0, 0, newState, deckPlayer0, deckPlayer1, false, false);
+				newState = newState.data_.getCurrentPlayerHero().takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, false);
 				toRet.addChild(newState);
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p0(); ++index) {
-					if (boardState.data_.getMinion_p0(index) == this)
+				for (int index = 0; index < boardState.data_.getCurrentPlayer().getNumMinions(); ++index) {
+					if (boardState.data_.getCurrentPlayer().getMinions().get(index) == this)
 						continue;
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p0(index);
-					newState = minion.takeDamage(BATTLECRY_DAMAGE, 0, 0, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion minion = newState.data_.getCurrentPlayer().getMinions().get(index);
+					newState = minion.takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
@@ -204,15 +204,15 @@ public class FireElemental extends Minion {
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-				newState = newState.data_.getHero_p1().takeDamage(BATTLECRY_DAMAGE, 0, 1, newState, deckPlayer0, deckPlayer1, false, false);
+				newState = newState.data_.getWaitingPlayerHero().takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, false);
 				toRet.addChild(newState);
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p1(); ++index) {		
+				for (int index = 0; index < boardState.data_.getWaitingPlayer().getNumMinions(); ++index) {
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p1(index);
-					newState = minion.takeDamage(BATTLECRY_DAMAGE, 0, 1, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion minion = newState.data_.getWaitingPlayer().getMinions().get(index);
+					newState = minion.takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}

--- a/src/main/java/com/hearthsim/card/minion/concrete/FlesheatingGhoul.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/FlesheatingGhoul.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class FlesheatingGhoul extends Minion {
@@ -158,18 +159,16 @@ public class FlesheatingGhoul extends Minion {
 	 * 
 	 * Whenever a minion dies, gain +1 Attack
 	 * 
-	 * @param thisMinionPlayerIndex The index of the damaged minion's player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param deadMinionPlayerIndex The player index of the dead minion.
-	 * @param deadMinion The dead minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param deadMinionPlayerModel
+     *@param deadMinion The dead minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionDeadEvent(
-			int thisMinionPlayerIndex,
-			int deadMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel deadMinionPlayerModel,
 			Minion deadMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,

--- a/src/main/java/com/hearthsim/card/minion/concrete/FrostwolfWarlord.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/FrostwolfWarlord.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -161,16 +162,15 @@ public class FrostwolfWarlord extends Minion {
 	 * 
 	 * Battlecry: gain +1/+1 for each friendly minion on the battlefield
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -184,14 +184,14 @@ public class FrostwolfWarlord extends Minion {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
-		int numBuffs = boardState.data_.getNumMinions_p0();
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		int numBuffs = boardState.data_.getCurrentPlayer().getNumMinions();
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 
 		this.setAttack((byte)(this.getAttack() + numBuffs));
 		this.setHealth((byte)(this.getHealth() + numBuffs));
@@ -204,14 +204,14 @@ public class FrostwolfWarlord extends Minion {
 	 * 
 	 * Always use this function to "silence" minions
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deck
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode silenced(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
-		HearthTreeNode toRet = super.silenced(thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+	public HearthTreeNode silenced(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+		HearthTreeNode toRet = super.silenced(thisPlayerModel, boardState, deckPlayer0, deckPlayer1);
 		this.attack_ = this.baseAttack_;
 		if (this.maxHealth_ > this.baseHealth_) {
 			this.maxHealth_ = this.baseHealth_;

--- a/src/main/java/com/hearthsim/card/minion/concrete/GnomishInventor.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/GnomishInventor.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -161,16 +162,15 @@ public class GnomishInventor extends Minion {
 	 * 
 	 * Battlecry: Draw one card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,7 +178,7 @@ public class GnomishInventor extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			if (toRet instanceof CardDrawNode)
 				((CardDrawNode) toRet).addNumCardsToDraw(1);

--- a/src/main/java/com/hearthsim/card/minion/concrete/GrimscaleOracle.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/GrimscaleOracle.java
@@ -7,6 +7,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -163,17 +164,18 @@ public class GrimscaleOracle extends Murloc {
 	 * 
 	 * Override for the temporary buff to attack
 	 * 
-	 * @param targetPlayerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param targetMinion The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param targetMinion The index of the target minion.
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0
+     * @param deckPlayer1
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -181,16 +183,16 @@ public class GrimscaleOracle extends Murloc {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			
-			for (Minion minion : boardState.data_.getMinions_p0()) {
+			for (Minion minion : boardState.data_.getCurrentPlayer().getMinions()) {
 				if (minion instanceof Murloc && minion != this) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() + 1));
 				}
 			}
 			
-			for (Minion minion : boardState.data_.getMinions_p1()) {
+			for (Minion minion : boardState.data_.getWaitingPlayer().getMinions()) {
 				if (minion instanceof Murloc && minion != this) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() + 1));
 				}
@@ -208,27 +210,27 @@ public class GrimscaleOracle extends Murloc {
 	 * 
 	 * Override for the aura effect
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deck
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode silenced(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+	public HearthTreeNode silenced(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
 		HearthTreeNode toRet = boardState;
 		if (!silenced_) {
-			for (Minion minion : toRet.data_.getMinions_p0()) {
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
 				if (minion instanceof Murloc && minion != this) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 				}
 			}
-			for (Minion minion : toRet.data_.getMinions_p1()) {
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
 				if (minion instanceof Murloc && minion != this) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 				}
 			}
 		}
-		toRet = this.silenced(thisPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		toRet = this.silenced(thisPlayerModel, toRet, deckPlayer0, deckPlayer1);
 		return toRet;
 	}
 	
@@ -237,39 +239,34 @@ public class GrimscaleOracle extends Murloc {
 	 * 
 	 * Override for the aura effect
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param thisMinionIndex The minion index of this minion
-	 * @param boardState 
-	 * @param deck
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode destroyed(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
+	public HearthTreeNode destroyed(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
 		
 		HearthTreeNode toRet = boardState;
 		if (!silenced_) {
-			for (Minion minion : toRet.data_.getMinions_p0()) {
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
 				if (minion instanceof Murloc && minion != this) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 				}
 			}
-			for (Minion minion : toRet.data_.getMinions_p1()) {
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
 				if (minion instanceof Murloc && minion != this) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 				}
 			}
 		}
-		toRet = super.destroyed(thisPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		toRet = super.destroyed(thisPlayerModel, toRet, deckPlayer0, deckPlayer1);
 		return toRet;
 	}
 	
 	private HearthTreeNode doBuffs(
-			int thisMinionPlayerIndex,
-			int targetMinionPlayerIndex,
-			Minion targetMinion,
-			HearthTreeNode boardState,
-			Deck deckPlayer0,
-			Deck deckPlayer1)
+            Minion targetMinion,
+            HearthTreeNode boardState)
 		throws HSInvalidPlayerIndexException
 	{
         if (!silenced_ && targetMinion instanceof Murloc && targetMinion != this) {
@@ -284,45 +281,45 @@ public class GrimscaleOracle extends Murloc {
 	 * 
 	 * Override for the aura effect
 	 *
-	 * @param playerIndex The index of the created minion's player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the created minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param summonedMinionPlayerModel
+     *@param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *  @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode minionSummonedEvent(
-			int thisMinionPlayerIndex,
-			int summonedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel summonedMinionPlayerModel,
 			Minion summonedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		return this.doBuffs(thisMinionPlayerIndex, summonedMinionPlayerIndex, summonedMinion, boardState, deckPlayer0, deckPlayer1);
+		return this.doBuffs(summonedMinion, boardState);
 	}
 	
 	/**
 	 * 
 	 * Called whenever another minion is summoned using a spell
 	 * 
-	 * @param playerIndex The index of the created minion's player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the created minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param transformedMinionPlayerModel
+     *@param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *  @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode minionTransformedEvent(
-			int thisMinionPlayerIndex,
-			int transformedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel transformedMinionPlayerModel,
 			Minion transformedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		return this.doBuffs(thisMinionPlayerIndex, transformedMinionPlayerIndex, transformedMinion, boardState, deckPlayer0, deckPlayer1);
+		return this.doBuffs(transformedMinion, boardState);
 	}
 }

--- a/src/main/java/com/hearthsim/card/minion/concrete/GuardianOfKings.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/GuardianOfKings.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -161,16 +162,15 @@ public class GuardianOfKings extends Minion {
 	 * 
 	 * Battlecry: Restore 6 health to your hero
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,10 +178,10 @@ public class GuardianOfKings extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null)
-			toRet = boardState.data_.getHero_p0().takeHeal((byte)6, 0, boardState, deckPlayer0, deckPlayer1);
+			toRet = boardState.data_.getCurrentPlayerHero().takeHeal((byte)6, boardState.data_.getCurrentPlayer(), boardState, deckPlayer0, deckPlayer1);
 		
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/GurubashiBerserker.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/GurubashiBerserker.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -162,19 +163,16 @@ public class GurubashiBerserker extends Minion {
 	 * Override for special ability: gain +3 attack whenever this minion takes damage
 	 * 
 	 * @param damage The amount of damage to take
-	 * @param attackerPlayerIndex The player index of the attacker.  This is needed to do things like +spell damage.
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param thisMinionIndex The minion index of this minion
-	 * @param boardState 
-	 * @param deck
-	 * @param isSpellDamage True if this is a spell damage
-	 * @throws HSInvalidPlayerIndexException
+	 * @param attackPlayerModel The player index of the attacker.  This is needed to do things like +spell damage.
+	 * @param thisPlayerModel
+     *@param boardState
+     * @param isSpellDamage True if this is a spell damage   @throws HSInvalidPlayerIndexException
 	 */
 	@Override
 	public HearthTreeNode takeDamage(
 			byte damage,
-			int attackerPlayerIndex,
-			int thisPlayerIndex,
+			PlayerModel attackPlayerModel,
+			PlayerModel thisPlayerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0, 
 			Deck deckPlayer1,
@@ -183,7 +181,7 @@ public class GurubashiBerserker extends Minion {
 		throws HSException
 	{
 		if (!divineShield_) {
-			HearthTreeNode toRet = super.takeDamage(damage, attackerPlayerIndex, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1, isSpellDamage, handleMinionDeath);
+			HearthTreeNode toRet = super.takeDamage(damage, attackPlayerModel, thisPlayerModel, boardState, deckPlayer0, deckPlayer1, isSpellDamage, handleMinionDeath);
 			if (!silenced_)
 				this.attack_ = (byte)(this.attack_ + 3);
 			return toRet;
@@ -198,15 +196,14 @@ public class GurubashiBerserker extends Minion {
 	 * 
 	 * Always use this function to "silence" minions
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param thisMinionIndex The minion index of this minion
-	 * @param boardState 
-	 * @param deck
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode silenced(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
-		HearthTreeNode toRet = super.silenced(thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+	public HearthTreeNode silenced(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+		HearthTreeNode toRet = super.silenced(thisPlayerModel, boardState, deckPlayer0, deckPlayer1);
 		this.attack_ = this.baseAttack_;
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/HealingTotem.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/HealingTotem.java
@@ -7,6 +7,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -164,15 +165,15 @@ public class HealingTotem extends Totem {
 	 * 
 	 */
 	@Override
-	public BoardModel endTurn(int thisMinionPlayerIndex, BoardModel boardModel, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
+	public BoardModel endTurn(PlayerModel thisMinionPlayerIndex, BoardModel boardModel, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
 		BoardModel tmpState = super.endTurn(thisMinionPlayerIndex, boardModel, deckPlayer0, deckPlayer1);
-		if (thisMinionPlayerIndex > 0)
+		if (thisMinionPlayerIndex == boardModel.getWaitingPlayer())
 			return tmpState;
 		
 		HearthTreeNode toRet = new HearthTreeNode(tmpState);
 	
-		for (Minion minion : toRet.data_.getMinions_p0()) {
-			toRet = minion.takeHeal((byte)1, 0, toRet, deckPlayer0, deckPlayer1);
+		for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
+			toRet = minion.takeHeal((byte)1, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
 		}
 		
 		if (toRet instanceof CardDrawNode) {

--- a/src/main/java/com/hearthsim/card/minion/concrete/Houndmaster.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Houndmaster.java
@@ -7,6 +7,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -162,15 +163,16 @@ public class Houndmaster extends Minion {
 	 * 
 	 * Battlecry: Give a friendly beast +2/+2 and Taunt
 	 * 
-	 * @param targetPlayerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param targetMinion The target minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param targetMinion The target minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,14 +180,14 @@ public class Houndmaster extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
-                if (index != toRet.data_.getMinions_p0().indexOf(this) && toRet.data_.getMinion_p0(index) instanceof Beast) {
+			for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
+                if (index != toRet.data_.getCurrentPlayer().getMinions().indexOf(this) && toRet.data_.getCurrentPlayer().getMinions().get(index) instanceof Beast) {
                     HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel) toRet.data_.deepCopy()));
-                    newState.data_.getMinion_p0(index).setAttack((byte) (newState.data_.getMinion_p0(index).getAttack() + 2));
-                    newState.data_.getMinion_p0(index).setHealth((byte) (newState.data_.getMinion_p0(index).getHealth() + 2));
-                    newState.data_.getMinion_p0(index).setTaunt(true);
+                    newState.data_.getCurrentPlayer().getMinions().get(index).setAttack((byte) (newState.data_.getCurrentPlayer().getMinions().get(index).getAttack() + 2));
+                    newState.data_.getCurrentPlayer().getMinions().get(index).setHealth((byte) (newState.data_.getCurrentPlayer().getMinions().get(index).getHealth() + 2));
+                    newState.data_.getCurrentPlayer().getMinions().get(index).setTaunt(true);
                 }
 			}
 		}

--- a/src/main/java/com/hearthsim/card/minion/concrete/InjuredBlademaster.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/InjuredBlademaster.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class InjuredBlademaster extends Minion {
@@ -160,15 +161,16 @@ public class InjuredBlademaster extends Minion {
 	 * 
 	 * Battlecry: Deal 4 damage to himself
 	 * 
-	 * @param targetPlayerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param targetMinion The target minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param targetMinion The target minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -176,9 +178,9 @@ public class InjuredBlademaster extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet = this.takeDamage((byte)4, targetPlayerIndex, targetPlayerIndex, boardState, deckPlayer0, deckPlayer1, false, true);
+			toRet = this.takeDamage((byte)4, playerModel, playerModel, boardState, deckPlayer0, deckPlayer1, false, true);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/IronbeakOwl.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/IronbeakOwl.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class IronbeakOwl extends Minion {
@@ -160,16 +161,15 @@ public class IronbeakOwl extends Minion {
 	 * 
 	 * Battlecry: Silence a minion
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -177,25 +177,25 @@ public class IronbeakOwl extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p0(); ++index) {
-					if (boardState.data_.getMinion_p0(index) == this)
+				for (int index = 0; index < boardState.data_.getCurrentPlayer().getNumMinions(); ++index) {
+					if (boardState.data_.getCurrentPlayer().getMinions().get(index) == this)
 						continue;
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p0(index);
-					newState = minion.silenced(0, newState, deckPlayer0, deckPlayer1);
+					Minion minion = newState.data_.getCurrentPlayer().getMinions().get(index);
+					newState = minion.silenced(newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p1(); ++index) {		
+				for (int index = 0; index < boardState.data_.getWaitingPlayer().getNumMinions(); ++index) {
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p1(index);
-					newState = minion.silenced(1, newState, deckPlayer0, deckPlayer1);
+					Minion minion = newState.data_.getWaitingPlayer().getMinions().get(index);
+					newState = minion.silenced(newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
 			}

--- a/src/main/java/com/hearthsim/card/minion/concrete/IronforgeRifleman.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/IronforgeRifleman.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.factory.BoardStateFactoryBase;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -164,16 +165,15 @@ public class IronforgeRifleman extends Minion {
 	 * 
 	 * Battlecry: Deal 1 damage to a chosen target
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -181,22 +181,22 @@ public class IronforgeRifleman extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-				newState = newState.data_.getHero_p0().takeDamage(BATTLECRY_DAMAGE, 0, 0, newState, deckPlayer0, deckPlayer1, false, false);
+				newState = newState.data_.getCurrentPlayerHero().takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, false);
 				toRet.addChild(newState);
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p0(); ++index) {
-					if (boardState.data_.getMinion_p0(index) == this)
+				for (int index = 0; index < boardState.data_.getCurrentPlayer().getNumMinions(); ++index) {
+					if (boardState.data_.getCurrentPlayer().getMinions().get(index) == this)
 						continue;
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p0(index);
-					newState = minion.takeDamage(BATTLECRY_DAMAGE, 0, 0, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion minion = newState.data_.getCurrentPlayer().getMinions().get(index);
+					newState = minion.takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
@@ -204,15 +204,15 @@ public class IronforgeRifleman extends Minion {
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-				newState = newState.data_.getHero_p1().takeDamage(BATTLECRY_DAMAGE, 0, 1, newState, deckPlayer0, deckPlayer1, false, false);
+				newState = newState.data_.getWaitingPlayerHero().takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, false);
 				toRet.addChild(newState);
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p1(); ++index) {		
+				for (int index = 0; index < boardState.data_.getWaitingPlayer().getNumMinions(); ++index) {
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p1(index);
-					newState = minion.takeDamage(BATTLECRY_DAMAGE, 0, 1, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion minion = newState.data_.getWaitingPlayer().getMinions().get(index);
+					newState = minion.takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}

--- a/src/main/java/com/hearthsim/card/minion/concrete/Leokk.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Leokk.java
@@ -7,6 +7,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -163,15 +164,16 @@ public class Leokk extends Beast {
 	 * 
 	 * Override for the temporary buff to attack
 	 * 
-	 * @param targetPlayerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param targetMinion The target minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param targetMinion The target minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -179,9 +181,9 @@ public class Leokk extends Beast {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p0()) {
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
 				if (minion != this) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() + 1));
 				}
@@ -195,21 +197,22 @@ public class Leokk extends Beast {
 	 * 
 	 * Override for the aura effect
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode silenced(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+	public HearthTreeNode silenced(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
 		HearthTreeNode toRet = boardState;
-		for (Minion minion : toRet.data_.getMinions(thisPlayerIndex)) {
+		for (Minion minion : toRet.data_.getMinions(thisPlayerModel)) {
 			if (minion != this) {
 				minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 			}
 		}
-		return super.silenced(thisPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		return super.silenced(thisPlayerModel, toRet, deckPlayer0, deckPlayer1);
 	}
 	
 	/**
@@ -217,31 +220,30 @@ public class Leokk extends Beast {
 	 * 
 	 * Override for the aura effect
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode destroyed(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
+	public HearthTreeNode destroyed(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
 		HearthTreeNode toRet = boardState;
-		for (Minion minion : toRet.data_.getMinions(thisPlayerIndex)) {
+		for (Minion minion : toRet.data_.getMinions(thisPlayerModel)) {
 			if (minion != this) {
 				minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 			}
 		}
-		return super.destroyed(thisPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		return super.destroyed(thisPlayerModel, toRet, deckPlayer0, deckPlayer1);
 	}
 	
 	private HearthTreeNode doBuffs(
-			int thisMinionPlayerIndex,
-			int placedMinionPlayerIndex,
-			Minion placedMinion,
-			HearthTreeNode boardState,
-			Deck deckPlayer0,
-			Deck deckPlayer1) throws HSInvalidPlayerIndexException {
-		if (thisMinionPlayerIndex != placedMinionPlayerIndex)
+            PlayerModel thisMinionPlayerModel,
+            PlayerModel placedMinionPlayerModel,
+            Minion placedMinion,
+            HearthTreeNode boardState) throws HSInvalidPlayerIndexException {
+		if (thisMinionPlayerModel != placedMinionPlayerModel)
 			return boardState;
 		if (placedMinion != this)
 			placedMinion.setAuraAttack((byte)(placedMinion.getAuraAttack() + 1));
@@ -254,50 +256,45 @@ public class Leokk extends Beast {
 	 * 
 	 * Override for the aura effect
 	 *
-	 * @param thisMinionPlayerIndex The player index of this minion
-	 * @param summonedMinionPlayerIndex The index of the summoned minion's player.
-	 * @param summonedMinion The summoned minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param summonedMinionPlayerModel
+     *@param summonedMinion The summoned minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionSummonedEvent(
-			int thisMinionPlayerIndex,
-			int summonedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel summonedMinionPlayerModel,
 			Minion summonedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		return this.doBuffs(thisMinionPlayerIndex, summonedMinionPlayerIndex, summonedMinion, boardState, deckPlayer0, deckPlayer1);
+		return this.doBuffs(thisMinionPlayerModel, summonedMinionPlayerModel, summonedMinion, boardState);
 	}
 	
 	/**
 	 * 
 	 * Called whenever another minion is summoned using a spell
 	 * 
-	 * @param thisMinionPlayerIndex The player index of this minion
-	 * @param transformedMinionPlayerIndex The index of the transformed minion's player.
-	 * @param transformedMinion The transformed minion (the minion that resulted from a transformation)
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 * @param thisMinionPlayerModel The player index of this minion
+	 * @param transformedMinionPlayerModel
+     *@param transformedMinion The transformed minion (the minion that resulted from a transformation)
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionTransformedEvent(
-			int thisMinionPlayerIndex,
-			int transformedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel transformedMinionPlayerModel,
 			Minion transformedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		return this.doBuffs(thisMinionPlayerIndex, transformedMinionPlayerIndex, transformedMinion, boardState, deckPlayer0, deckPlayer1);
+		return this.doBuffs(thisMinionPlayerModel, transformedMinionPlayerModel, transformedMinion, boardState);
 	}
 
 }

--- a/src/main/java/com/hearthsim/card/minion/concrete/MurlocTidehunter.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/MurlocTidehunter.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Murloc;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -163,16 +164,15 @@ public class MurlocTidehunter extends Murloc {
 	 * 
 	 * Battlecry: Summons a Murloc Scout
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -186,17 +186,17 @@ public class MurlocTidehunter extends Murloc {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
-		if (toRet != null && toRet.data_.getNumMinions_p0() < 7) {
+		if (toRet != null && toRet.data_.getCurrentPlayer().getNumMinions() < 7) {
 			Minion newMinion = new MurlocScout();
-			newMinion.summonMinion(targetPlayerIndex, this, boardState, deckPlayer0, deckPlayer1, false);
+			newMinion.summonMinion(playerModel, this, boardState, deckPlayer0, deckPlayer1, false);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/Nightblade.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Nightblade.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -161,17 +162,17 @@ public class Nightblade extends Minion {
 	 * 
 	 * Battlecry: Heals friendly characters for 2
 	 * 
-	 * @param targetPlayerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param targetMinion The target minion (can be a Hero).  If it is a Hero, then the minion is placed on the last (right most) spot on the board.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     *
+     * @param targetPlayer
+     * @param targetMinion The target minion (can be a Hero).  If it is a Hero, then the minion is placed on the last (right most) spot on the board.
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode useOn(
-			int targetPlayerIndex,
+			PlayerModel targetPlayer,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -179,10 +180,10 @@ public class Nightblade extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(targetPlayer, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 
 		if (toRet != null) 
-			toRet = toRet.data_.getHero_p1().takeDamage((byte)3, 0, 1, boardState, deckPlayer0, deckPlayer1, false, false);
+			toRet = toRet.data_.getWaitingPlayerHero().takeDamage((byte)3, boardState.data_.getCurrentPlayer(), boardState.data_.getWaitingPlayer(), boardState, deckPlayer0, deckPlayer1, false, false);
 		
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/NorthshireCleric.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/NorthshireCleric.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -169,18 +170,18 @@ public class NorthshireCleric extends Minion {
 	 * 
 	 * Called whenever another character (including the hero) is healed
 	 * 
-	 * @param thisMinionPlayerIndex The index of the damaged minion's player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param healedMinionPlayerIndex The player index of the healed minion.
-	 * @param healedMinion The healed minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer1 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param healedMinionPlayerModel
+     *@param healedMinion The healed minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0
+     * @param deckPlayer1 The deck of player1
+*     @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionHealedEvent(
-			int thisMinionPlayerIndex,
-			int healedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel healedMinionPlayerModel,
 			Minion healedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -189,7 +190,7 @@ public class NorthshireCleric extends Minion {
 	{
 		HearthTreeNode toRet = boardState;
 		if (!silenced_) {
-			if (thisMinionPlayerIndex == 0) {
+			if (thisMinionPlayerModel == boardState.data_.getCurrentPlayer()) {
 				if (boardState instanceof CardDrawNode) {
 					((CardDrawNode)toRet).addNumCardsToDraw(1);
 				} else {
@@ -197,7 +198,7 @@ public class NorthshireCleric extends Minion {
 				}
 			} else {
 				//This minion is an enemy minion.  Let's draw a card for the enemy.  No need to use a StopNode for enemy card draws.
-				toRet.data_.drawCardFromDeck_p1(deckPlayer1, 1);
+				toRet.data_.drawCardFromWaitingPlayerDeck(deckPlayer1, 1);
 			}
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/NoviceEngineer.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/NoviceEngineer.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -161,16 +162,15 @@ public class NoviceEngineer extends Minion {
 	 * 
 	 * Battlecry: draw one card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,7 +178,7 @@ public class NoviceEngineer extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			if (toRet instanceof CardDrawNode)
 				((CardDrawNode) toRet).addNumCardsToDraw(1);

--- a/src/main/java/com/hearthsim/card/minion/concrete/PriestessOfElune.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/PriestessOfElune.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class PriestessOfElune extends Minion {
@@ -160,16 +161,15 @@ public class PriestessOfElune extends Minion {
 	 * 
 	 * Battlecry: Restore 4 health to your hero
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -178,10 +178,10 @@ public class PriestessOfElune extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			toRet.data_.getHero_p0().takeHeal((byte)4, 0, toRet, deckPlayer0, deckPlayer1);
+			toRet.data_.getCurrentPlayerHero().takeHeal((byte)4, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
 			return toRet;
 		} else {
 			return null;

--- a/src/main/java/com/hearthsim/card/minion/concrete/RaidLeader.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/RaidLeader.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -162,16 +163,15 @@ public class RaidLeader extends Minion {
 	 * 
 	 * Override for the temporary buff to attack
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -179,9 +179,9 @@ public class RaidLeader extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p0()) {
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
 				if (minion != this) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() + 1));
 				}
@@ -195,21 +195,22 @@ public class RaidLeader extends Minion {
 	 * 
 	 * Override for the aura effect
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode silenced(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+	public HearthTreeNode silenced(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
 		HearthTreeNode toRet = boardState;
-		for (Minion minion : toRet.data_.getMinions(thisPlayerIndex)) {
+		for (Minion minion : toRet.data_.getMinions(thisPlayerModel)) {
 			if (minion != this) {
 				minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 			}
 		}
-		return super.silenced(thisPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		return super.silenced(thisPlayerModel, toRet, deckPlayer0, deckPlayer1);
 	}
 	
 	/**
@@ -217,31 +218,32 @@ public class RaidLeader extends Minion {
 	 * 
 	 * Override for the aura effect
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param boardState 
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode destroyed(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
+	public HearthTreeNode destroyed(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
 		HearthTreeNode toRet = boardState;
-		for (Minion minion : toRet.data_.getMinions(thisPlayerIndex)) {
+		for (Minion minion : toRet.data_.getMinions(thisPlayerModel)) {
 			if (minion != this) {
 				minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 			}
 		}
-		return super.destroyed(thisPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		return super.destroyed(thisPlayerModel, toRet, deckPlayer0, deckPlayer1);
 	}
 	
 	private HearthTreeNode doBuffs(
-			int thisMinionPlayerIndex,
-			int placedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel placedMinionPlayerModel,
 			Minion placedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1) throws HSInvalidPlayerIndexException {
-		if (thisMinionPlayerIndex != placedMinionPlayerIndex)
+		if (thisMinionPlayerModel != placedMinionPlayerModel)
 			return boardState;
         if (!silenced_ && placedMinion != this) {
             placedMinion.setAuraAttack((byte) (placedMinion.getAuraAttack() + 1));
@@ -255,49 +257,44 @@ public class RaidLeader extends Minion {
 	 * 
 	 * Override for the aura effect
 	 *
-	 * @param thisMinionPlayerIndex The player index of this minion
-	 * @param summonedMinionPlayerIndex The index of the summoned minion's player.
-	 * @param summonedMinion The summoned minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param summonedMinionPlayerModel
+     *@param summonedMinion The summoned minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionSummonedEvent(
-			int thisMinionPlayerIndex,
-			int summonedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel summonedMinionPlayerModel,
 			Minion summonedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		return this.doBuffs(thisMinionPlayerIndex, summonedMinionPlayerIndex, summonedMinion, boardState, deckPlayer0, deckPlayer1);
+		return this.doBuffs(thisMinionPlayerModel, summonedMinionPlayerModel, summonedMinion, boardState, deckPlayer0, deckPlayer1);
 	}
 	
 	/**
 	 * 
 	 * Called whenever another minion is summoned using a spell
 	 * 
-	 * @param thisMinionPlayerIndex The player index of this minion
-	 * @param transformedMinionPlayerIndex The index of the transformed minion's player.
-	 * @param transformedMinion The transformed minion (the minion that resulted from a transformation)
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 * @param thisMinionPlayerModel The player index of this minion
+	 * @param transformedMinionPlayerModel
+     *@param transformedMinion The transformed minion (the minion that resulted from a transformation)
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionTransformedEvent(
-			int thisMinionPlayerIndex,
-			int transformedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel transformedMinionPlayerModel,
 			Minion transformedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		return this.doBuffs(thisMinionPlayerIndex, transformedMinionPlayerIndex, transformedMinion, boardState, deckPlayer0, deckPlayer1);
+		return this.doBuffs(thisMinionPlayerModel, transformedMinionPlayerModel, transformedMinion, boardState, deckPlayer0, deckPlayer1);
 	}
 }

--- a/src/main/java/com/hearthsim/card/minion/concrete/RazorfenHunter.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/RazorfenHunter.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -161,16 +162,15 @@ public class RazorfenHunter extends Minion {
 	 * 
 	 * Battlecry: Summons a 1/1 Boar
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -184,17 +184,17 @@ public class RazorfenHunter extends Minion {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
-		if (toRet != null && toRet.data_.getNumMinions_p0() < 7) {
+		if (toRet != null && toRet.data_.getCurrentPlayer().getNumMinions() < 7) {
 			Minion newMinion = new Boar();
-			newMinion.summonMinion(targetPlayerIndex, this, boardState, deckPlayer0, deckPlayer1, false);
+			newMinion.summonMinion(playerModel, this, boardState, deckPlayer0, deckPlayer1, false);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/ShatteredSunCleric.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/ShatteredSunCleric.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -175,16 +176,15 @@ public class ShatteredSunCleric extends Minion {
 	 * 
 	 * Battlecry: Give a friendly minion +1/+1
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -193,14 +193,14 @@ public class ShatteredSunCleric extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
-				if (index != toRet.data_.getMinions_p0().indexOf(this)) {
+			for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
+				if (index != toRet.data_.getCurrentPlayer().getMinions().indexOf(this)) {
 					HearthTreeNode newState = toRet.addChild(new HearthTreeNode((BoardModel)toRet.data_.deepCopy()));
-					newState.data_.getMinion_p0(index).setAttack((byte)(newState.data_.getMinion_p0(index).getAttack() + 1));
-					newState.data_.getMinion_p0(index).setHealth((byte)(newState.data_.getMinion_p0(index).getHealth() + 1));
+					newState.data_.getCurrentPlayer().getMinions().get(index).setAttack((byte)(newState.data_.getCurrentPlayer().getMinions().get(index).getAttack() + 1));
+					newState.data_.getCurrentPlayer().getMinions().get(index).setHealth((byte)(newState.data_.getCurrentPlayer().getMinions().get(index).getHealth() + 1));
 				}
 			}
 			return toRet;

--- a/src/main/java/com/hearthsim/card/minion/concrete/SilverHandKnight.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/SilverHandKnight.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -162,16 +163,15 @@ public class SilverHandKnight extends Minion {
 	 * 
 	 * Battlecry: Summons a Squire
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -185,17 +185,17 @@ public class SilverHandKnight extends Minion {
 			return null;
 		}
 		
-		if (targetPlayerIndex == 1)
+		if (boardState.data_.getWaitingPlayer() == playerModel)
 			return null;
 		
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
-		if (toRet != null && toRet.data_.getNumMinions_p0() < 7) {
+		if (toRet != null && toRet.data_.getCurrentPlayer().getNumMinions() < 7) {
 			Minion newMinion = new Squire();
-			newMinion.summonMinion(targetPlayerIndex, this, boardState, deckPlayer0, deckPlayer1, false);
+			newMinion.summonMinion(playerModel, this, boardState, deckPlayer0, deckPlayer1, false);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/Spellbreaker.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Spellbreaker.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Spellbreaker extends Minion {
@@ -160,16 +161,15 @@ public class Spellbreaker extends Minion {
 	 * 
 	 * Battlecry: Silence a minion
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -177,25 +177,25 @@ public class Spellbreaker extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p0(); ++index) {
-					if (boardState.data_.getMinion_p0(index) == this)
+				for (int index = 0; index < boardState.data_.getCurrentPlayer().getNumMinions(); ++index) {
+					if (boardState.data_.getCurrentPlayer().getMinions().get(index) == this)
 						continue;
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p0(index);
-					newState = minion.silenced(0, newState, deckPlayer0, deckPlayer1);
+					Minion minion = newState.data_.getCurrentPlayer().getMinions().get(index);
+					newState = minion.silenced(newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p1(); ++index) {		
+				for (int index = 0; index < boardState.data_.getWaitingPlayer().getNumMinions(); ++index) {
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p1(index);
-					newState = minion.silenced(1, newState, deckPlayer0, deckPlayer1);
+					Minion minion = newState.data_.getWaitingPlayer().getMinions().get(index);
+					newState = minion.silenced(newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
 			}

--- a/src/main/java/com/hearthsim/card/minion/concrete/StarvingBuzzard.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/StarvingBuzzard.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -162,29 +163,28 @@ public class StarvingBuzzard extends Beast {
 	 * 
 	 * The buzzard draws a card whenever a Beast is placed on the battlefield
 	 * 
-	 * @param thisMinionPlayerIndex The player index of this minion
-	 * @param summonedMinionPlayerIndex The index of the summoned minion's player.
-	 * @param summonedMinion The summoned minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param summonedMinionPlayerModel
+     *@param summonedMinion The summoned minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionSummonedEvent(
-			int thisMinionPlayerIndex,
-			int summonedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel summonedMinionPlayerModel,
 			Minion summonedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		if (summonedMinionPlayerIndex == 1 || thisMinionPlayerIndex == 1)
+        PlayerModel waitingPlayer = boardState.data_.getWaitingPlayer();
+        if (summonedMinionPlayerModel == waitingPlayer || thisMinionPlayerModel == waitingPlayer)
 			return boardState;
 		
-		HearthTreeNode toRet = super.minionSummonedEvent(thisMinionPlayerIndex, summonedMinionPlayerIndex, summonedMinion, boardState, deckPlayer0, deckPlayer1);
-		if (toRet.data_.getMinion_p0(summonedMinionPlayerIndex - 1) instanceof Beast) {
+		HearthTreeNode toRet = super.minionSummonedEvent(thisMinionPlayerModel, summonedMinionPlayerModel, summonedMinion, boardState, deckPlayer0, deckPlayer1);
+		if (summonedMinion instanceof Beast) { //todo: this might be wrong..
 			if (toRet instanceof CardDrawNode) {
 				((CardDrawNode) toRet).addNumCardsToDraw(1);
 			} else {

--- a/src/main/java/com/hearthsim/card/minion/concrete/StormpikeCommando.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/StormpikeCommando.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.factory.BoardStateFactoryBase;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -164,16 +165,15 @@ public class StormpikeCommando extends Minion {
 	 * 
 	 * Battlecry: Deal 2 damage to a chosen target
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -181,22 +181,22 @@ public class StormpikeCommando extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-				newState = newState.data_.getHero_p0().takeDamage(BATTLECRY_DAMAGE, 0, 0, newState, deckPlayer0, deckPlayer1, false, false);
+				newState = newState.data_.getCurrentPlayerHero().takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, false);
 				toRet.addChild(newState);
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p0(); ++index) {
-					if (boardState.data_.getMinion_p0(index) == this)
+				for (int index = 0; index < boardState.data_.getCurrentPlayer().getNumMinions(); ++index) {
+					if (boardState.data_.getCurrentPlayer().getMinions().get(index) == this)
 						continue;
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p0(index);
-					newState = minion.takeDamage(BATTLECRY_DAMAGE, 0, 0, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion minion = newState.data_.getCurrentPlayer().getMinions().get(index);
+					newState = minion.takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
@@ -204,15 +204,15 @@ public class StormpikeCommando extends Minion {
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-				newState = newState.data_.getHero_p1().takeDamage(BATTLECRY_DAMAGE, 0, 1, newState, deckPlayer0, deckPlayer1, false, false);
+				newState = newState.data_.getWaitingPlayerHero().takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, false);
 				toRet.addChild(newState);
 			}
 
 			{
-				for (int index = 0; index < boardState.data_.getNumMinions_p1(); ++index) {		
+				for (int index = 0; index < boardState.data_.getWaitingPlayer().getNumMinions(); ++index) {
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)boardState.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p1(index);
-					newState = minion.takeDamage(BATTLECRY_DAMAGE, 0, 1, newState, deckPlayer0, deckPlayer1, false, true);
+					Minion minion = newState.data_.getWaitingPlayer().getMinions().get(index);
+					newState = minion.takeDamage(BATTLECRY_DAMAGE, newState.data_.getCurrentPlayer(), newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1, false, true);
 					newState = BoardStateFactoryBase.handleDeadMinions(newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}

--- a/src/main/java/com/hearthsim/card/minion/concrete/Succubus.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Succubus.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -162,16 +163,15 @@ public class Succubus extends Demon {
 	 * 
 	 * Battlecry: Discard a random card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -180,13 +180,13 @@ public class Succubus extends Demon {
 		throws HSException
 	{
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
-		int numCards = toRet.data_.getNumCards_hand_p0();
+		int numCards = toRet.data_.getNumCardsHandCurrentPlayer();
 		if (numCards <= 0)
 			return null;
 		int cardToDiscardIndex = (int)(Math.random() * numCards);
-		toRet.data_.removeCard_hand(toRet.data_.getMinion_p0(cardToDiscardIndex));
+		toRet.data_.removeCard_hand(toRet.data_.getCurrentPlayer().getMinions().get(cardToDiscardIndex));
 							
 		return boardState;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/TempleEnforcer.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/TempleEnforcer.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class TempleEnforcer extends Minion {
@@ -160,16 +161,15 @@ public class TempleEnforcer extends Minion {
 	 * 
 	 * Battlecry: Give a friendly minion +3 health
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -177,15 +177,15 @@ public class TempleEnforcer extends Minion {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 
 			{
-				for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
-					if (toRet.data_.getMinion_p0(index) == this)
+				for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
+					if (toRet.data_.getCurrentPlayer().getMinions().get(index) == this)
 						continue;
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-					Minion minion = newState.data_.getMinion_p0(index);
+					Minion minion = newState.data_.getCurrentPlayer().getMinions().get(index);
 					minion.setHealth((byte)(minion.getHealth() + 3));
 					toRet.addChild(newState);
 				}

--- a/src/main/java/com/hearthsim/card/minion/concrete/TimberWolf.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/TimberWolf.java
@@ -7,6 +7,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -163,16 +164,15 @@ public class TimberWolf extends Beast {
 	 * 
 	 * Override for the temporary buff to attack
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -180,9 +180,9 @@ public class TimberWolf extends Beast {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p0()) {
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
 				if (minion != this && minion instanceof Beast) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() + 1));
 				}
@@ -196,23 +196,22 @@ public class TimberWolf extends Beast {
 	 * 
 	 * Override for the aura effect
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param thisMinionIndex The minion index of this minion
-	 * @param boardState 
-	 * @param deck
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode silenced(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+	public HearthTreeNode silenced(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
 		HearthTreeNode toRet = boardState;
 		if (!silenced_) {
-			for (Minion minion : toRet.data_.getMinions(thisPlayerIndex)) {
+			for (Minion minion : toRet.data_.getMinions(thisPlayerModel)) {
 				if (minion != this && minion instanceof Beast) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 				}
 			}
 		}
-		toRet = super.silenced(thisPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		toRet = super.silenced(thisPlayerModel, toRet, deckPlayer0, deckPlayer1);
 		return toRet;
 	}
 	
@@ -221,34 +220,33 @@ public class TimberWolf extends Beast {
 	 * 
 	 * Override for the aura effect
 	 * 
-	 * @param thisPlayerIndex The player index of this minion
-	 * @param thisMinionIndex The minion index of this minion
-	 * @param boardState 
-	 * @param deck
-	 * @throws HSInvalidPlayerIndexException
+	 *
+     * @param thisPlayerModel
+     * @param boardState
+     * @throws HSInvalidPlayerIndexException
 	 */
 	@Override
-	public HearthTreeNode destroyed(int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
-		HearthTreeNode toRet = super.destroyed(thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+	public HearthTreeNode destroyed(PlayerModel thisPlayerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
+		HearthTreeNode toRet = super.destroyed(thisPlayerModel, boardState, deckPlayer0, deckPlayer1);
 		if (!silenced_) {
-			for (Minion minion : toRet.data_.getMinions(thisPlayerIndex)) {
+			for (Minion minion : toRet.data_.getMinions(thisPlayerModel)) {
 				if (minion != this && minion instanceof Beast) {
 					minion.setAuraAttack((byte)(minion.getAuraAttack() - 1));
 				}
 			}
 		}
-		return super.destroyed(thisPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		return super.destroyed(thisPlayerModel, toRet, deckPlayer0, deckPlayer1);
 	}
 	
 	private HearthTreeNode doBuffs(
-			int thisMinionPlayerIndex,
-			int placedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel placedMinionPlayerModel,
 			Minion placedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1) throws HSInvalidPlayerIndexException
 	{
-		if (placedMinionPlayerIndex != thisMinionPlayerIndex)
+		if (placedMinionPlayerModel != thisMinionPlayerModel)
 			return boardState;
         if (!silenced_ && placedMinion != this && placedMinion instanceof Beast) {
             placedMinion.setAuraAttack((byte) (placedMinion.getAuraAttack() + 1));
@@ -263,49 +261,44 @@ public class TimberWolf extends Beast {
 	 * 
 	 * Override for the aura effect
 	 *
-	 * @param thisMinionPlayerIndex The player index of this minion
-	 * @param summonedMinionPlayerIndex The index of the summoned minion's player.
-	 * @param summonedMinion The summoned minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param thisMinionPlayerModel
+     * @param summonedMinionPlayerModel
+     *@param summonedMinion The summoned minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionSummonedEvent(
-			int thisMinionPlayerIndex,
-			int summonedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel summonedMinionPlayerModel,
 			Minion summonedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		return this.doBuffs(thisMinionPlayerIndex, summonedMinionPlayerIndex, summonedMinion, boardState, deckPlayer0, deckPlayer1);
+		return this.doBuffs(thisMinionPlayerModel, summonedMinionPlayerModel, summonedMinion, boardState, deckPlayer0, deckPlayer1);
 	}
 	
 	/**
 	 * 
 	 * Called whenever another minion is summoned using a spell
 	 * 
-	 * @param thisMinionPlayerIndex The player index of this minion
-	 * @param transformedMinionPlayerIndex The index of the transformed minion's player.
-	 * @param transformedMinion The transformed minion (the minion that resulted from a transformation)
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 * @param thisMinionPlayerModel The player index of this minion
+	 * @param transformedMinionPlayerModel
+     *@param transformedMinion The transformed minion (the minion that resulted from a transformation)
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0    @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode minionTransformedEvent(
-			int thisMinionPlayerIndex,
-			int transformedMinionPlayerIndex,
+			PlayerModel thisMinionPlayerModel,
+			PlayerModel transformedMinionPlayerModel,
 			Minion transformedMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSInvalidPlayerIndexException
 	{
-		return this.doBuffs(thisMinionPlayerIndex, transformedMinionPlayerIndex, transformedMinion, boardState, deckPlayer0, deckPlayer1);
+		return this.doBuffs(thisMinionPlayerModel, transformedMinionPlayerModel, transformedMinion, boardState, deckPlayer0, deckPlayer1);
 	}
 }

--- a/src/main/java/com/hearthsim/card/minion/concrete/VioletTeacher.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/VioletTeacher.java
@@ -7,6 +7,7 @@ import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class VioletTeacher extends Minion {
@@ -161,26 +162,25 @@ public class VioletTeacher extends Minion {
 	 * 
 	 * When you cast a spell, summon a 1/1 Violet Apprentice
 	 * 
-	 * @param thisCardPlayerIndex The player index of the card receiving the event
-	 * @param cardUserPlayerIndex The player index of the player that used the card
-	 * @param usedCard The card that was used
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer1 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 * @param thisCardPlayerModel The player index of the card receiving the event
+	 * @param cardUserPlayerModel
+     *@param usedCard The card that was used
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0
+     * @param deckPlayer1 The deck of player1
+*     @return The boardState is manipulated and returned
 	 * @throws HSException 
 	 */
 	@Override
-	public HearthTreeNode otherCardUsedEvent(int thisCardPlayerIndex, int cardUserPlayerIndex, Card usedCard, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
-		HearthTreeNode toRet = super.otherCardUsedEvent(thisCardPlayerIndex, cardUserPlayerIndex, usedCard, boardState, deckPlayer0, deckPlayer1);
-		if (thisCardPlayerIndex != 0)
+	public HearthTreeNode otherCardUsedEvent(PlayerModel thisCardPlayerModel, PlayerModel cardUserPlayerModel, Card usedCard, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
+		HearthTreeNode toRet = super.otherCardUsedEvent(thisCardPlayerModel, cardUserPlayerModel, usedCard, boardState, deckPlayer0, deckPlayer1);
+		if (thisCardPlayerModel != toRet.data_.getCurrentPlayer())
 			return toRet;
 		if (isInHand_)
 			return toRet;
-        if (usedCard instanceof SpellCard && toRet.data_.getNumMinions_p0() < 7) {
+        if (usedCard instanceof SpellCard && toRet.data_.getCurrentPlayer().getNumMinions() < 7) {
             Minion newMinion = new VioletApprentice();
-            toRet = newMinion.summonMinion(thisCardPlayerIndex, this, toRet, deckPlayer0, deckPlayer1, false);
+            toRet = newMinion.summonMinion(thisCardPlayerModel, this, toRet, deckPlayer0, deckPlayer1, false);
         }
         return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/concrete/VoodooDoctor.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/VoodooDoctor.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -163,16 +164,15 @@ public class VoodooDoctor extends Minion {
 	 * 
 	 * Battlecry: Restore 2 health
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -181,33 +181,33 @@ public class VoodooDoctor extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-				newState = newState.data_.getHero_p0().takeHeal((byte)2, 0, newState, deckPlayer0, deckPlayer1);
+				newState = newState.data_.getCurrentPlayerHero().takeHeal((byte)2, newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1);
 				toRet.addChild(newState);
 			}
 			
 			{
-				for (int index = 0; index < toRet.data_.getNumMinions_p0(); ++index) {
+				for (int index = 0; index < toRet.data_.getCurrentPlayer().getNumMinions(); ++index) {
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-					newState = newState.data_.getMinion_p0(index).takeHeal((byte)2, 0, newState, deckPlayer0, deckPlayer1);
+					newState = newState.data_.getCurrentPlayer().getMinions().get(index).takeHeal((byte)2, newState.data_.getCurrentPlayer(), newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
 			}
 
 			{
 				HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-				newState = newState.data_.getHero_p1().takeHeal((byte)2, 1, newState, deckPlayer0, deckPlayer1);
+				newState = newState.data_.getWaitingPlayerHero().takeHeal((byte)2, newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1);
 				toRet.addChild(newState);
 			}
 			
 			{
-				for (int index = 0; index < toRet.data_.getNumMinions_p1(); ++index) {
+				for (int index = 0; index < toRet.data_.getWaitingPlayer().getNumMinions(); ++index) {
 					HearthTreeNode newState = new HearthTreeNode((BoardModel)toRet.data_.deepCopy());
-					newState = newState.data_.getMinion_p1(index).takeHeal((byte)2, 1, newState, deckPlayer0, deckPlayer1);
+					newState = newState.data_.getWaitingPlayer().getMinions().get(index).takeHeal((byte)2, newState.data_.getWaitingPlayer(), newState, deckPlayer0, deckPlayer1);
 					toRet.addChild(newState);
 				}
 			}

--- a/src/main/java/com/hearthsim/card/minion/concrete/WaterElemental.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/WaterElemental.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -161,23 +162,22 @@ public class WaterElemental extends Minion {
 	 * 
 	 * Any minion attacked by this minion is frozen.
 	 * 
-	 * @param targetMinionPlayerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param targetMinion The target minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param targetMinionPlayerModel
+     * @param targetMinion The target minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0
+     * @return The boardState is manipulated and returned
 	 */
 	protected HearthTreeNode attack_core(
-			int targetMinionPlayerIndex,
+			PlayerModel targetMinionPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.attack_core(targetMinionPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.attack_core(targetMinionPlayerModel, targetMinion, boardState, deckPlayer0, deckPlayer1);
 		if (!silenced_ && toRet != null) {
 			targetMinion.setFrozen(true);
 		}

--- a/src/main/java/com/hearthsim/card/minion/concrete/Windspeaker.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Windspeaker.java
@@ -6,6 +6,7 @@ import com.hearthsim.event.attack.AttackAction;
 import com.hearthsim.event.deathrattle.DeathrattleAction;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -162,16 +163,15 @@ public class Windspeaker extends Minion {
 	 * 
 	 * Battlecry: Give a friendly minion windfury
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	public HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -180,12 +180,12 @@ public class Windspeaker extends Minion {
 		throws HSException
 	{
 		//A generic card does nothing except for consuming mana
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			for (int index = 0; index < boardState.data_.getNumMinions_p0(); ++index) {
+			for (int index = 0; index < boardState.data_.getCurrentPlayer().getNumMinions(); ++index) {
 				HearthTreeNode newState = boardState.addChild(new HearthTreeNode((BoardModel)boardState.data_.deepCopy()));
-				newState.data_.getMinion_p0(index).hasWindFuryAttacked(true);
+				newState.data_.getCurrentPlayer().getMinions().get(index).hasWindFuryAttacked(true);
 			}
 			return toRet;
 		} else {

--- a/src/main/java/com/hearthsim/card/minion/heroes/Druid.java
+++ b/src/main/java/com/hearthsim/card/minion/heroes/Druid.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -55,17 +56,18 @@ public class Druid extends Hero {
 	 * 
 	 * Druid: +1 attack this turn and +1 armor
 	 * 
-	 * @param targetPlayerIndex The player index of the target character
-	 * @param targetMinion The target minion
-	 * @param boardState
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * 
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param targetMinion The target minion
+     * @param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1
+     *
+     * @return
 	 */
 	@Override
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -73,10 +75,10 @@ public class Druid extends Hero {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetMinion instanceof Hero  && targetPlayerIndex == 0) {
+		if (targetMinion instanceof Hero  && targetPlayerModel == boardState.data_.getCurrentPlayer()) {
 			this.hasBeenUsed_ = true;
 			boardState.data_.setMana_p0(boardState.data_.getMana_p0() - HERO_ABILITY_COST);
-			Hero target = boardState.data_.getHero_p0();
+			Hero target = boardState.data_.getCurrentPlayerHero();
 			target.setExtraAttackUntilTurnEnd((byte)1);
 			target.setArmor((byte)1);
 			return boardState;

--- a/src/main/java/com/hearthsim/card/minion/heroes/Hunter.java
+++ b/src/main/java/com/hearthsim/card/minion/heroes/Hunter.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -55,17 +56,18 @@ public class Hunter extends Hero {
 	 * 
 	 * Hunter: Deals 2 damage to enemy hero
 	 * 
-	 * @param targetPlayerIndex The player index of the target character
-	 * @param targetMinion The target minion
-	 * @param boardState
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * 
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param targetMinion The target minion
+     * @param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1
+     *
+     * @return
 	 */
 	@Override
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -74,10 +76,10 @@ public class Hunter extends Hero {
 		throws HSException
 	{
 		HearthTreeNode toRet = boardState;
-		if (targetMinion instanceof Hero && targetPlayerIndex == 1) {
+		if (targetMinion instanceof Hero && targetPlayerModel == toRet.data_.getWaitingPlayer()) {
 			this.hasBeenUsed_ = true;
 			toRet.data_.setMana_p0(toRet.data_.getMana_p0() - HERO_ABILITY_COST);
-			toRet = targetMinion.takeDamage((byte)2, 0, targetPlayerIndex, toRet, deckPlayer0, deckPlayer1, false, false);
+			toRet = targetMinion.takeDamage((byte)2, toRet.data_.getCurrentPlayer(), targetPlayerModel, toRet, deckPlayer0, deckPlayer1, false, false);
 			return toRet;
 		} else {
 			return null;

--- a/src/main/java/com/hearthsim/card/minion/heroes/Mage.java
+++ b/src/main/java/com/hearthsim/card/minion/heroes/Mage.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -55,17 +56,18 @@ public class Mage extends Hero {
 	 * 
 	 * Mage: deals 1 damage
 	 * 
-	 * @param targetPlayerIndex The player index of the target character
-	 * @param targetMinion The target minion
-	 * @param boardState
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * 
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param targetMinion The target minion
+     * @param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1
+     *
+     * @return
 	 */
 	@Override
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -74,13 +76,13 @@ public class Mage extends Hero {
 		throws HSException
 	{
 		HearthTreeNode toRet = boardState;
-		if (targetPlayerIndex == 0 && targetMinion instanceof Hero) {
+		if (targetPlayerModel == boardState.data_.getCurrentPlayer() && targetMinion instanceof Hero) {
 			//There's never a case where using it on yourself is a good idea
 			return null;
 		}
 		this.hasBeenUsed_ = true;
 		toRet.data_.setMana_p0(toRet.data_.getMana_p0() - HERO_ABILITY_COST);
-		toRet = targetMinion.takeDamage((byte)1, 0, targetPlayerIndex, toRet, deckPlayer0, deckPlayer1, false, true);
+		toRet = targetMinion.takeDamage((byte)1, boardState.data_.getCurrentPlayer(), targetPlayerModel, toRet, deckPlayer0, deckPlayer1, false, true);
 		
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/heroes/Paladin.java
+++ b/src/main/java/com/hearthsim/card/minion/heroes/Paladin.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.minion.concrete.SilverHandRecruit;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -56,16 +57,14 @@ public class Paladin extends Hero {
 	 * 
 	 * Paladin: summon a 1/1 Silver Hand Recruit
 	 * 
-	 * @param thisPlayerIndex The player index of the hero
-	 * @param targetPlayerIndex The player index of the target character
-	 * @param targetMinionIndex The minion index of the target character
-	 * @param boardState
-	 * @param deck
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param boardState
+     * @return
 	 */
 	@Override
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -73,17 +72,17 @@ public class Paladin extends Hero {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (boardState.data_.getNumMinions_p0() >= 7)
+		if (boardState.data_.getCurrentPlayer().getNumMinions() >= 7)
 			return null;
 
 		HearthTreeNode toRet = boardState;
 
-		if (targetMinion instanceof Hero && targetPlayerIndex == 0) {
+		if (targetMinion instanceof Hero && targetPlayerModel == boardState.data_.getCurrentPlayer()) {
 			this.hasBeenUsed_ = true;
 			toRet.data_.setMana_p0(toRet.data_.getMana_p0() - HERO_ABILITY_COST);
 			Minion theRecruit = new SilverHandRecruit();
-			Minion targetLocation = toRet.data_.getCharacter(0, toRet.data_.getNumMinions_p0());
-			toRet = theRecruit.summonMinion(targetPlayerIndex, targetLocation, toRet, deckPlayer0, deckPlayer1, false);
+			Minion targetLocation = toRet.data_.getCharacter(toRet.data_.getCurrentPlayer(), toRet.data_.getCurrentPlayer().getNumMinions());
+			toRet = theRecruit.summonMinion(targetPlayerModel, targetLocation, toRet, deckPlayer0, deckPlayer1, false);
 		} else {
 			return null;
 		}

--- a/src/main/java/com/hearthsim/card/minion/heroes/Priest.java
+++ b/src/main/java/com/hearthsim/card/minion/heroes/Priest.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -55,16 +56,14 @@ public class Priest extends Hero {
 	 * 
 	 * Priest: Heals a target for 2
 	 * 
-	 * @param thisPlayerIndex The player index of the hero
-	 * @param targetPlayerIndex The player index of the target character
-	 * @param targetMinionIndex The minion index of the target character
-	 * @param boardState
-	 * @param deck
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param boardState
+     * @return
 	 */
 	@Override
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -75,7 +74,7 @@ public class Priest extends Hero {
 		HearthTreeNode toRet = boardState;
 		this.hasBeenUsed_ = true;
 		toRet.data_.setMana_p0(toRet.data_.getMana_p0() - HERO_ABILITY_COST);
-		toRet = targetMinion.takeHeal((byte)2, targetPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+		toRet = targetMinion.takeHeal((byte)2, targetPlayerModel, toRet, deckPlayer0, deckPlayer1);
 
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/minion/heroes/Rogue.java
+++ b/src/main/java/com/hearthsim/card/minion/heroes/Rogue.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -55,16 +56,14 @@ public class Rogue extends Hero {
 	 * 
 	 * Rogue: equip a 1 attack, 2 charge weapon
 	 * 
-	 * @param thisPlayerIndex The player index of the hero
-	 * @param targetPlayerIndex The player index of the target character
-	 * @param targetMinionIndex The minion index of the target character
-	 * @param boardState
-	 * @param deck
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param boardState
+     * @return
 	 */
 	@Override
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -73,7 +72,7 @@ public class Rogue extends Hero {
 		throws HSException
 	{
 		HearthTreeNode toRet = boardState;
-		if (targetMinion instanceof Hero && targetPlayerIndex == 0) {
+		if (targetMinion instanceof Hero && targetPlayerModel == boardState.data_.getCurrentPlayer()) {
 			this.hasBeenUsed_ = true;
 			toRet.data_.setMana_p0(toRet.data_.getMana_p0() - HERO_ABILITY_COST);
 			Hero target = (Hero)targetMinion;

--- a/src/main/java/com/hearthsim/card/minion/heroes/Warlock.java
+++ b/src/main/java/com/hearthsim/card/minion/heroes/Warlock.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
@@ -56,17 +57,18 @@ public class Warlock extends Hero {
 	 * 
 	 * Warlock: draw a card and take 2 damage
 	 * 
-	 * @param targetPlayerIndex The player index of the target character
-	 * @param targetMinion The target minion
-	 * @param boardState
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * 
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param targetMinion The target minion
+     * @param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1
+     *
+     * @return
 	 */
 	@Override
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -74,9 +76,9 @@ public class Warlock extends Hero {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex != 0 || !(targetMinion instanceof Hero))
+		if (targetPlayerModel == boardState.data_.getWaitingPlayer() || !(targetMinion instanceof Hero))
 			return null;
-		HearthTreeNode toRet = targetMinion.takeDamage((byte)2, 0, 0, boardState, deckPlayer0, deckPlayer1, false, false);
+		HearthTreeNode toRet = targetMinion.takeDamage((byte)2, boardState.data_.getCurrentPlayer(), boardState.data_.getCurrentPlayer(), boardState, deckPlayer0, deckPlayer1, false, false);
 		if (toRet != null) {
 			this.hasBeenUsed_ = true;
 			toRet.data_.setMana_p0(toRet.data_.getMana_p0() - HERO_ABILITY_COST);

--- a/src/main/java/com/hearthsim/card/minion/heroes/Warrior.java
+++ b/src/main/java/com/hearthsim/card/minion/heroes/Warrior.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.DeepCopyable;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -55,16 +56,14 @@ public class Warrior extends Hero {
 	 * 
 	 * Warrior: +2 armor
 	 * 
-	 * @param thisPlayerIndex The player index of the hero
-	 * @param targetPlayerIndex The player index of the target character
-	 * @param targetMinionIndex The minion index of the target character
-	 * @param boardState
-	 * @param deck
-	 * @return
+	 *
+     * @param targetPlayerModel
+     * @param boardState
+     * @return
 	 */
 	@Override
 	public HearthTreeNode useHeroAbility_core(
-			int targetPlayerIndex,
+			PlayerModel targetPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -73,7 +72,7 @@ public class Warrior extends Hero {
 		throws HSException
 	{
 		HearthTreeNode toRet = boardState;
-		if (targetMinion instanceof Hero && targetPlayerIndex == 0) {
+		if (targetMinion instanceof Hero && targetPlayerModel == boardState.data_.getCurrentPlayer()) {
 			this.hasBeenUsed_ = true;
 			toRet.data_.setMana_p0(toRet.data_.getMana_p0() - HERO_ABILITY_COST);
 			((Hero)targetMinion).setArmor((byte)(((Hero)targetMinion).getArmor() + 2));

--- a/src/main/java/com/hearthsim/card/spellcard/SpellCard.java
+++ b/src/main/java/com/hearthsim/card/spellcard/SpellCard.java
@@ -2,6 +2,8 @@ package com.hearthsim.card.spellcard;
 
 import com.hearthsim.card.Card;
 import com.hearthsim.card.minion.Minion;
+import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import org.json.JSONObject;
 
 
@@ -17,7 +19,7 @@ public class SpellCard extends Card {
 	}
 
     @Override
-    public boolean canBeUsedOn(int playerIndex, Minion minion) {
+    public boolean canBeUsedOn(PlayerModel playerModel, Minion minion, BoardModel boardModel) {
         return !hasBeenUsed_ && !minion.getStealthed();
     }
 

--- a/src/main/java/com/hearthsim/card/spellcard/SpellDamage.java
+++ b/src/main/java/com/hearthsim/card/spellcard/SpellDamage.java
@@ -3,6 +3,7 @@ package com.hearthsim.card.spellcard;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 import org.json.JSONObject;
 
@@ -63,23 +64,22 @@ public class SpellDamage extends SpellCard {
 	 * 
 	 * Attack using this spell
 	 * 
-	 * @param targetMinionPlayerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param targetMinion The target minion
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * @param deckPlayer0 The deck of player0
-	 * @param deckPlayer0 The deck of player1
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param targetMinionPlayerModel
+     * @param targetMinion The target minion
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     * @param deckPlayer0 The deck of player0
+     * @return The boardState is manipulated and returned
 	 */
 	public HearthTreeNode attack(
-			int targetMinionPlayerIndex,
+			PlayerModel targetMinionPlayerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1)
 		throws HSException
 	{
-		return targetMinion.takeDamage(damage_, 0, targetMinionPlayerIndex, boardState, deckPlayer0, deckPlayer1, true, false);
+		return targetMinion.takeDamage(damage_, boardState.data_.getCurrentPlayer(), targetMinionPlayerModel, boardState, deckPlayer0, deckPlayer1, true, false);
  	}
 	
 	/**
@@ -88,15 +88,14 @@ public class SpellDamage extends SpellCard {
 	 * 
 	 * This is the core implementation of card's ability
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -112,7 +111,7 @@ public class SpellDamage extends SpellCard {
 		this.hasBeenUsed(true);
 		HearthTreeNode toRet = boardState;
 
-		toRet = this.attack(targetPlayerIndex, targetMinion, toRet, deckPlayer0, deckPlayer1);
+		toRet = this.attack(playerModel, targetMinion, toRet, deckPlayer0, deckPlayer1);
 		toRet.data_.setMana_p0(toRet.data_.getMana_p0() - this.mana_);
 		toRet.data_.removeCard_hand(this);
 		

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/AncestralHealing.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/AncestralHealing.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class AncestralHealing extends SpellCard {
@@ -38,16 +39,15 @@ public class AncestralHealing extends SpellCard {
 	 * 
 	 * This card heals the target minion up to full health and gives it taunt.  Cannot be used on heroes.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -59,10 +59,10 @@ public class AncestralHealing extends SpellCard {
 			//cant't use it on the heroes
 			return null;
 		}
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			if (targetMinion.getHealth() < targetMinion.getMaxHealth()) 
-				toRet = targetMinion.takeHeal((byte)(targetMinion.getMaxHealth() - targetMinion.getHealth()), targetPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+				toRet = targetMinion.takeHeal((byte)(targetMinion.getMaxHealth() - targetMinion.getHealth()), playerModel, boardState, deckPlayer0, deckPlayer1);
 			targetMinion.setTaunt(true);
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/AncestralSpirit.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/AncestralSpirit.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.event.deathrattle.DeathrattleSummonMinionAction;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class AncestralSpirit extends SpellCard {
@@ -38,16 +39,15 @@ public class AncestralSpirit extends SpellCard {
 	 * 
 	 * Give a minion 'Deathrattle: Resummon this minion'
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -59,7 +59,7 @@ public class AncestralSpirit extends SpellCard {
 			//cant't use it on the heroes
 			return null;
 		}
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setDeathrattle(new DeathrattleSummonMinionAction(targetMinion.getClass(), 1));
 		}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/AnimalCompanion.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/AnimalCompanion.java
@@ -8,6 +8,7 @@ import com.hearthsim.card.minion.concrete.Leokk;
 import com.hearthsim.card.minion.concrete.Misha;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class AnimalCompanion extends SpellCard {
@@ -42,16 +43,15 @@ public class AnimalCompanion extends SpellCard {
 	 * 
 	 * Summons either Huffer, Leokk, or Misha
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -59,11 +59,11 @@ public class AnimalCompanion extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (!(targetMinion instanceof Hero) || targetPlayerIndex == 1) {
+		if (!(targetMinion instanceof Hero) || boardState.data_.getWaitingPlayer() == playerModel) {
 			return null;
 		}
 		
-		int numMinions = boardState.data_.getNumMinions_p0();
+		int numMinions = boardState.data_.getCurrentPlayer().getNumMinions();
 		if (numMinions >= 7)
 			return null;
 		
@@ -77,10 +77,10 @@ public class AnimalCompanion extends SpellCard {
 			minion = new Misha();
 		}
 		boardState.data_.setMana_p0(boardState.data_.getMana_p0() + 3);
-		boardState.data_.placeCard_hand_p0(minion);
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		boardState.data_.placeCardHandCurrentPlayer(minion);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) 
-			toRet = minion.useOn(targetPlayerIndex, boardState.data_.getMinion_p0(numMinions - 1), toRet, deckPlayer0, deckPlayer1, singleRealizationOnly);
+			toRet = minion.useOn(playerModel, boardState.data_.getCurrentPlayer().getMinions().get(numMinions - 1), toRet, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		return toRet;
 	}
 

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/ArcaneExplosion.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/ArcaneExplosion.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class ArcaneExplosion extends SpellCard {
@@ -38,16 +39,15 @@ public class ArcaneExplosion extends SpellCard {
 	 * 
 	 * This card damages all enemy minions by 1
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,7 +55,7 @@ public class ArcaneExplosion extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0) {
+		if (boardState.data_.getCurrentPlayer() == playerModel) {
 			return null;
 		}
 		
@@ -63,10 +63,11 @@ public class ArcaneExplosion extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p1()) {
-				toRet = minion.takeDamage((byte)1, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+
+				toRet = minion.takeDamage((byte)1, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/ArcaneIntellect.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/ArcaneIntellect.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -39,16 +40,15 @@ public class ArcaneIntellect extends SpellCard {
 	 * 
 	 * This card draws 2 cards from the deck.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,11 +56,11 @@ public class ArcaneIntellect extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 1 || !(targetMinion instanceof Hero)) {
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero)) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet instanceof CardDrawNode)
 			((CardDrawNode) toRet).addNumCardsToDraw(2);
 		else

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Assassinate.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Assassinate.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Assassinate extends SpellCard {
@@ -38,16 +39,15 @@ public class Assassinate extends SpellCard {
 	 * 
 	 * This card destroys an enemy minion.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,11 +55,11 @@ public class Assassinate extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0 || targetMinion instanceof Hero) {
+		if (boardState.data_.getCurrentPlayer() == playerModel || targetMinion instanceof Hero) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setHealth((byte)-99);
 		}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Backstab.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Backstab.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Backstab extends SpellDamage {
@@ -28,16 +29,15 @@ public class Backstab extends SpellDamage {
 	 * 
 	 * Using this card damages a minion by 2 if the minion is not already damaged.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -48,7 +48,7 @@ public class Backstab extends SpellDamage {
 		if (targetMinion instanceof Hero)
 			return null;
 		if (targetMinion.getHealth() == targetMinion.getMaxHealth()) {
-			return super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+			return super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		} else {
 			return null;
 		}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Bite.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Bite.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Bite extends SpellCard {
@@ -38,16 +39,15 @@ public class Bite extends SpellCard {
 	 * 
 	 * Gives a minion +4/+4
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,11 +55,11 @@ public class Bite extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (!(targetMinion instanceof Hero) || targetPlayerIndex == 1) {
+		if (!(targetMinion instanceof Hero) || boardState.data_.getWaitingPlayer() == playerModel) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			Hero hero = (Hero)targetMinion;
 			hero.setExtraAttackUntilTurnEnd((byte)(hero.getExtraAttackUntilTurnEnd() + 4));

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/BlessingOfKings.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/BlessingOfKings.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class BlessingOfKings extends SpellCard {
@@ -38,16 +39,15 @@ public class BlessingOfKings extends SpellCard {
 	 * 
 	 * Gives a minion +4/+4
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -59,7 +59,7 @@ public class BlessingOfKings extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setAttack((byte)(targetMinion.getAttack() + 4));
 			targetMinion.setHealth((byte)(targetMinion.getHealth() + 4));

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/BlessingOfMight.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/BlessingOfMight.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class BlessingOfMight extends SpellCard {
@@ -37,16 +38,15 @@ public class BlessingOfMight extends SpellCard {
 	 * 
 	 * Gives a minion +3 attack
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -58,7 +58,7 @@ public class BlessingOfMight extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
 			targetMinion.setAttack((byte)(targetMinion.getAttack() + 3));
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Bloodlust.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Bloodlust.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Bloodlust extends SpellCard {
@@ -28,16 +29,15 @@ public class Bloodlust extends SpellCard {
 	 * 
 	 * Give your minions +3 attack for this turn
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -45,13 +45,13 @@ public class Bloodlust extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 1 || !(targetMinion instanceof Hero)) {
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero)) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
-		for (Minion minion : toRet.data_.getMinions_p0()) {
+		for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
 			minion.setExtraAttackUntilTurnEnd((byte)3);
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Charge.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Charge.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Charge extends SpellCard {
@@ -38,16 +39,15 @@ public class Charge extends SpellCard {
 	 * 
 	 * This card gives the target +2 attack and Charge.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,12 +55,12 @@ public class Charge extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetMinion instanceof Hero || targetPlayerIndex == 1) {
+		if (targetMinion instanceof Hero || boardState.data_.getWaitingPlayer() == playerModel) {
 			//cant't use it on the heroes or enemy minions
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setAttack((byte)(targetMinion.getAttack() + 2));
 			targetMinion.setCharge(true);

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/CircleOfHealing.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/CircleOfHealing.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class CircleOfHealing extends SpellCard {
@@ -41,16 +42,15 @@ public class CircleOfHealing extends SpellCard {
 	 * 
 	 * Heals all minions for 4
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -58,16 +58,16 @@ public class CircleOfHealing extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex > 0 || !(targetMinion instanceof Hero)) 
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero))
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
-		for (Minion minion : toRet.data_.getMinions_p0()) {
-			toRet = minion.takeHeal(HEAL_AMOUNT, 0, toRet, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
+			toRet = minion.takeHeal(HEAL_AMOUNT, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
 		}
 
-		for (Minion minion : toRet.data_.getMinions_p1()) {
-			toRet = minion.takeHeal(HEAL_AMOUNT, 1, toRet, deckPlayer0, deckPlayer1);
+		for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+			toRet = minion.takeHeal(HEAL_AMOUNT, toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1);
 		}
 
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Claw.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Claw.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Claw extends SpellCard {
@@ -40,16 +41,15 @@ public class Claw extends SpellCard {
 	 * 
 	 * Gives the hero +2 attack for this turn and +2 armor
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,11 +57,11 @@ public class Claw extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 1 || !(targetMinion instanceof Hero)) {
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero)) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setExtraAttackUntilTurnEnd((byte)(DAMAGE_AMOUNT + targetMinion.getExtraAttackUntilTurnEnd()));
 			((Hero)targetMinion).setArmor(ARMOR_AMOUNT);

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Consecration.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Consecration.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Consecration extends SpellCard {
@@ -40,16 +41,15 @@ public class Consecration extends SpellCard {
 	 * 
 	 * Deals 2 damage to all enemy characters
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,14 +57,14 @@ public class Consecration extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex > 0 || !(targetMinion instanceof Hero)) 
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero))
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet = toRet.data_.getHero_p1().takeDamage(DAMAGE_AMOUNT, 0, 0, toRet, deckPlayer0, deckPlayer1, true, false);
-			for (Minion minion : toRet.data_.getMinions_p1()) {
-				toRet = minion.takeDamage(DAMAGE_AMOUNT, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
+			toRet = toRet.data_.getWaitingPlayerHero().takeDamage(DAMAGE_AMOUNT, toRet.data_.getCurrentPlayer(), toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+				toRet = minion.takeDamage(DAMAGE_AMOUNT, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Corruption.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Corruption.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Corruption extends SpellCard {
@@ -38,16 +39,15 @@ public class Corruption extends SpellCard {
 	 * 
 	 * Choose an enemy minion.  At the start of your turn, destroy it.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,11 +55,11 @@ public class Corruption extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0 || targetMinion instanceof Hero) {
+		if (boardState.data_.getCurrentPlayer() == playerModel || targetMinion instanceof Hero) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
 			targetMinion.setDestroyOnTurnStart(true);
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/DeadlyPoison.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/DeadlyPoison.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DeadlyPoison extends SpellCard {
@@ -37,16 +38,15 @@ public class DeadlyPoison extends SpellCard {
 	 * 
 	 * Give your weapon +2 attack
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -54,14 +54,14 @@ public class DeadlyPoison extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 1 || !(targetMinion instanceof Hero)) {
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero)) {
 			return null;
 		}
 		Hero hero = (Hero)targetMinion;
 		if (hero.getWeaponCharge() == 0)
 			return null;
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			hero.setAttack((byte)(hero.getAttack() + 2));
 		}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/DivineSpirit.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/DivineSpirit.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DivineSpirit extends SpellCard {
@@ -39,16 +40,15 @@ public class DivineSpirit extends SpellCard {
 	 * 
 	 * This card heals the target minion up to full health and gives it taunt.  Cannot be used on heroes.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -61,7 +61,7 @@ public class DivineSpirit extends SpellCard {
 			return null;
 		}
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			byte healthDiff = targetMinion.getHealth();
 			targetMinion.setHealth((byte)(targetMinion.getHealth() * 2));

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/DrainLife.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/DrainLife.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DrainLife extends SpellDamage {
@@ -28,16 +29,15 @@ public class DrainLife extends SpellDamage {
 	 * 
 	 * Deals 2 damage and heals the hero for 2.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -45,12 +45,12 @@ public class DrainLife extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0 && targetMinion instanceof Hero)
+		if (boardState.data_.getCurrentPlayer() == playerModel && targetMinion instanceof Hero)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet.data_.getHero_p0().takeHeal((byte)2, 0, toRet, deckPlayer0, deckPlayer1);
+			toRet.data_.getCurrentPlayerHero().takeHeal((byte)2, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/ExcessMana.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/ExcessMana.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -39,16 +40,15 @@ public class ExcessMana extends SpellCard {
 	 * 
 	 * Draw one card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,11 +56,11 @@ public class ExcessMana extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (!(targetMinion instanceof Hero) || targetPlayerIndex == 1) {
+		if (!(targetMinion instanceof Hero) || boardState.data_.getWaitingPlayer() == playerModel) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			if (toRet instanceof CardDrawNode)
 				((CardDrawNode) toRet).addNumCardsToDraw(1);

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Execute.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Execute.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Execute extends SpellCard {
@@ -38,16 +39,15 @@ public class Execute extends SpellCard {
 	 * 
 	 * Destroy a damaged minion.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,14 +55,14 @@ public class Execute extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetMinion instanceof Hero || targetPlayerIndex == 0) {
+		if (targetMinion instanceof Hero || boardState.data_.getCurrentPlayer() == playerModel) {
 			//cant't use it on the heroes or friendly minion
 			return null;
 		}
 		if (targetMinion.getHealth() == targetMinion.getMaxHealth())
 			return null;
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setHealth((byte)-99);
 		}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/FanOfKnives.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/FanOfKnives.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -40,16 +41,15 @@ public class FanOfKnives extends SpellCard {
 	 * 
 	 * This card damages all enemy minions by 1 and draws a card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,7 +57,7 @@ public class FanOfKnives extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0) {
+		if (boardState.data_.getCurrentPlayer() == playerModel) {
 			return null;
 		}
 		
@@ -65,10 +65,10 @@ public class FanOfKnives extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p1()) {
-				toRet = minion.takeDamage((byte)1, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+				toRet = minion.takeDamage((byte)1, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 			
 			if (toRet instanceof CardDrawNode) {

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Flamestrike.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Flamestrike.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Flamestrike extends SpellCard {
@@ -38,16 +39,15 @@ public class Flamestrike extends SpellCard {
 	 * 
 	 * Deal 4 damage to all enemy minions
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,7 +55,7 @@ public class Flamestrike extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0) {
+		if (boardState.data_.getCurrentPlayer() == playerModel) {
 			return null;
 		}
 		
@@ -63,10 +63,10 @@ public class Flamestrike extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p1()) {
-				toRet = minion.takeDamage((byte)4, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+				toRet = minion.takeDamage((byte)4, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/FrostNova.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/FrostNova.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class FrostNova extends SpellCard {
@@ -37,16 +38,15 @@ public class FrostNova extends SpellCard {
 	 * 
 	 * This freeze all enemy minions
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -54,7 +54,7 @@ public class FrostNova extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0) {
+		if (boardState.data_.getCurrentPlayer() == playerModel) {
 			return null;
 		}
 		
@@ -62,9 +62,9 @@ public class FrostNova extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p1()) {
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
 				minion.setFrozen(true);
 			}
 		}		

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/FrostShock.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/FrostShock.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class FrostShock extends SpellDamage {
@@ -27,16 +28,15 @@ public class FrostShock extends SpellDamage {
 	 * 
 	 * Deals 1 damage and freezes an enemy
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -44,10 +44,10 @@ public class FrostShock extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0) 
+		if (boardState.data_.getCurrentPlayer() == playerModel)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setFrozen(true);
 		}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Frostbolt.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Frostbolt.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Frostbolt extends SpellDamage {
@@ -27,16 +28,15 @@ public class Frostbolt extends SpellDamage {
 	 * 
 	 * Deals 3 damage and freezes an enemy
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -44,10 +44,10 @@ public class Frostbolt extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0) 
+		if (boardState.data_.getCurrentPlayer() == playerModel)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setFrozen(true);
 		}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/HammerOfWrath.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/HammerOfWrath.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -28,16 +29,15 @@ public class HammerOfWrath extends SpellDamage {
 	 * 
 	 * Deals 3 damage and draws a cards
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -45,7 +45,7 @@ public class HammerOfWrath extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			if (toRet instanceof CardDrawNode) {
 				((CardDrawNode) toRet).addNumCardsToDraw(1);

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/HandOfProtection.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/HandOfProtection.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class HandOfProtection extends SpellCard {
@@ -38,16 +39,15 @@ public class HandOfProtection extends SpellCard {
 	 * 
 	 * This card gives a minion Divine Shield.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -62,7 +62,7 @@ public class HandOfProtection extends SpellCard {
 		if (targetMinion.getDivineShield())
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
 			targetMinion.setDivineShield(true);
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/HealingTouch.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/HealingTouch.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class HealingTouch extends SpellCard {
@@ -39,16 +40,15 @@ public class HealingTouch extends SpellCard {
 	 * 
 	 * Heal a character for 8
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,9 +56,9 @@ public class HealingTouch extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
-			toRet = targetMinion.takeHeal(HEAL_AMOUNT, targetPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+			toRet = targetMinion.takeHeal(HEAL_AMOUNT, playerModel, toRet, deckPlayer0, deckPlayer1);
 		return toRet;
 	}
 }

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Hellfire.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Hellfire.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Hellfire extends SpellCard {
@@ -40,16 +41,15 @@ public class Hellfire extends SpellCard {
 	 * 
 	 * Deals 3 damage to all characters
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,19 +57,19 @@ public class Hellfire extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex > 0 || !(targetMinion instanceof Hero)) 
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero))
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet = toRet.data_.getHero_p0().takeDamage(DAMAGE_AMOUNT, 0, 0, toRet, deckPlayer0, deckPlayer1, true, false);
-			for (Minion minion : toRet.data_.getMinions_p0()) {
-				toRet = minion.takeDamage(DAMAGE_AMOUNT, 0, 0, toRet, deckPlayer0, deckPlayer1, true, false);
+			toRet = toRet.data_.getCurrentPlayerHero().takeDamage(DAMAGE_AMOUNT, toRet.data_.getCurrentPlayer(), toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
+				toRet = minion.takeDamage(DAMAGE_AMOUNT, toRet.data_.getCurrentPlayer(), toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 	
-			toRet = toRet.data_.getHero_p1().takeDamage(DAMAGE_AMOUNT, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
-			for (Minion minion : toRet.data_.getMinions_p1()) {
-				toRet = minion.takeDamage(DAMAGE_AMOUNT, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
+			toRet = toRet.data_.getWaitingPlayerHero().takeDamage(DAMAGE_AMOUNT, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+				toRet = minion.takeDamage(DAMAGE_AMOUNT, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 		}		
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/HeroicStrike.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/HeroicStrike.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class HeroicStrike extends SpellCard {
@@ -39,16 +40,15 @@ public class HeroicStrike extends SpellCard {
 	 * 
 	 * Gives the hero +4 attack this turn
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,13 +56,13 @@ public class HeroicStrike extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 1 || !(targetMinion instanceof Hero)) {
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero)) {
 			return null;
 		}
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet.data_.getHero_p0().setExtraAttackUntilTurnEnd((byte)(DAMAGE_AMOUNT + toRet.data_.getHero_p0().getExtraAttackUntilTurnEnd()));
+			toRet.data_.getCurrentPlayerHero().setExtraAttackUntilTurnEnd((byte)(DAMAGE_AMOUNT + toRet.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd()));
 		}
 		
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Hex.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Hex.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.minion.concrete.Frog;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Hex extends SpellCard {
@@ -39,16 +40,15 @@ public class Hex extends SpellCard {
 	 * 
 	 * Transform a minion into 0/1 frog with Taunt
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -60,12 +60,12 @@ public class Hex extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet = targetMinion.silenced(targetPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+			toRet = targetMinion.silenced(playerModel, toRet, deckPlayer0, deckPlayer1);
 			Frog frog = new Frog();
-			toRet = frog.summonMinion(targetPlayerIndex, targetMinion, toRet, deckPlayer0, deckPlayer1, true);
-			toRet.data_.removeMinion(targetPlayerIndex, targetMinion);
+			toRet = frog.summonMinion(playerModel, targetMinion, toRet, deckPlayer0, deckPlayer1, true);
+			toRet.data_.removeMinion(targetMinion);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/HolyFire.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/HolyFire.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class HolyFire extends SpellDamage {
@@ -29,16 +30,15 @@ public class HolyFire extends SpellDamage {
 	 * 
 	 * Deals 5 damage and heals the hero for 5.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -46,12 +46,12 @@ public class HolyFire extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0 && targetMinion instanceof Hero)
+		if (boardState.data_.getCurrentPlayer() == playerModel && targetMinion instanceof Hero)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet.data_.getHero_p0().takeHeal((byte)5, 0, toRet, deckPlayer0, deckPlayer1);
+			toRet.data_.getCurrentPlayerHero().takeHeal((byte)5, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/HolyLight.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/HolyLight.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class HolyLight extends SpellCard {
@@ -39,16 +40,15 @@ public class HolyLight extends SpellCard {
 	 * 
 	 * Heal a character for 6
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,9 +56,9 @@ public class HolyLight extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
-			targetMinion.takeHeal(HEAL_AMOUNT, targetPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+			targetMinion.takeHeal(HEAL_AMOUNT, playerModel, toRet, deckPlayer0, deckPlayer1);
 		return toRet;
 	}
 }

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/HolyNova.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/HolyNova.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class HolyNova extends SpellCard {
@@ -39,16 +40,15 @@ public class HolyNova extends SpellCard {
 	 * 
 	 * Deal 2 damage to all enemy characters and heal all friendly characters by 2
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,7 +56,7 @@ public class HolyNova extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0) {
+		if (boardState.data_.getCurrentPlayer() == playerModel) {
 			return null;
 		}
 		
@@ -64,16 +64,16 @@ public class HolyNova extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet = toRet.data_.getHero_p0().takeHeal((byte)2, 0, toRet, deckPlayer0, deckPlayer1);
-			for (Minion minion : toRet.data_.getMinions_p0()) {
-				toRet = minion.takeHeal((byte)2, 0, toRet, deckPlayer0, deckPlayer1);
+			toRet = toRet.data_.getCurrentPlayerHero().takeHeal((byte)2, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
+				toRet = minion.takeHeal((byte)2, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
 			}
 			
-			toRet = toRet.data_.getHero_p1().takeDamage((byte)2, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
-			for (Minion minion : toRet.data_.getMinions_p1()) {
-				toRet = minion.takeDamage((byte)2, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
+			toRet = toRet.data_.getWaitingPlayerHero().takeDamage((byte)2, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+				toRet = minion.takeDamage((byte)2, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Humility.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Humility.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Humility extends SpellCard {
@@ -40,16 +41,15 @@ public class Humility extends SpellCard {
 	 * 
 	 * Set the attack of a minion to 1
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -60,7 +60,7 @@ public class Humility extends SpellCard {
 		if (targetMinion instanceof Hero) {
 			return null;
 		}
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
 			targetMinion.setAttack((byte)1);
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/HuntersMark.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/HuntersMark.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class HuntersMark extends SpellCard {
@@ -37,16 +38,15 @@ public class HuntersMark extends SpellCard {
 	 * 
 	 * This card damages all enemy minions by 1
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,7 +57,7 @@ public class HuntersMark extends SpellCard {
 		if (targetMinion instanceof Hero) {
 			return null;
 		}
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setHealth((byte)1);
 			targetMinion.setMaxHealth((byte)1);

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/InnerFire.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/InnerFire.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class InnerFire extends SpellCard {
@@ -38,16 +39,15 @@ public class InnerFire extends SpellCard {
 	 * 
 	 * Change a minion's Attack to be equal to its Health
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -58,7 +58,7 @@ public class InnerFire extends SpellCard {
 		if (targetMinion instanceof Hero) 
 			return null;
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setAttack(targetMinion.getTotalHealth());
 		}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/InnerRage.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/InnerRage.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class InnerRage extends SpellCard {
@@ -38,16 +39,15 @@ public class InnerRage extends SpellCard {
 	 * 
 	 * Deal 1 damage to a minion and give it +2 attack
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -58,9 +58,9 @@ public class InnerRage extends SpellCard {
 		if (targetMinion instanceof Hero) 
 			return null;
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet = targetMinion.takeDamage((byte)1, 0, targetPlayerIndex, boardState, deckPlayer0, deckPlayer1, true, false);
+			toRet = targetMinion.takeDamage((byte)1, boardState.data_.getCurrentPlayer(), playerModel, boardState, deckPlayer0, deckPlayer1, true, false);
 			targetMinion.setAttack((byte)(targetMinion.getAttack() + 2));
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Innervate.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Innervate.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Innervate extends SpellCard {
@@ -38,16 +39,15 @@ public class Innervate extends SpellCard {
 	 * 
 	 * Gives the hero 2 extra mana this turn.  If already at 10 mana, does nothing but the card still disappears.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,10 +55,10 @@ public class Innervate extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex > 0 || !(targetMinion instanceof Hero)) 
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero))
 			return null;
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			if (toRet.data_.getMana_p0() < 8)
 				toRet.data_.setMana_p0(toRet.data_.getMana_p0() + 2);

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/KillCommand.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/KillCommand.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Beast;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class KillCommand extends SpellDamage {
@@ -28,16 +29,15 @@ public class KillCommand extends SpellDamage {
 	 * 
 	 * Deals 3 damage.  If you have a beast, deals 5 damage.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -46,14 +46,14 @@ public class KillCommand extends SpellDamage {
 		throws HSException
 	{
 		boolean haveBeast = false;
-		for (final Minion minion : boardState.data_.getMinions_p0()) {
+		for (final Minion minion : boardState.data_.getCurrentPlayer().getMinions()) {
 			haveBeast = haveBeast || minion instanceof Beast;
 		}
 		if (haveBeast)
 			this.damage_ = (byte)5;
 		else
 			this.damage_ = (byte)3;
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/LayOnHands.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/LayOnHands.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -38,16 +39,15 @@ public class LayOnHands extends SpellCard {
 	 * 
 	 * Restore 8 Health and draw 3 cards
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,12 +56,12 @@ public class LayOnHands extends SpellCard {
 		throws HSException
 	{
 		//Let's assume that it is never beneficial to heal an opponent... though this may not strictly be true under some very corner cases (e.g., with a Northshire Cleric)
-		if (targetPlayerIndex == 1) {
+		if (boardState.data_.getWaitingPlayer() == playerModel) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
-		toRet = targetMinion.takeHeal((byte)8, targetPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		toRet = targetMinion.takeHeal((byte)8, playerModel, boardState, deckPlayer0, deckPlayer1);
 		if (toRet instanceof CardDrawNode)
 			((CardDrawNode) toRet).addNumCardsToDraw(3);
 		else

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/MarkOfTheWild.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/MarkOfTheWild.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class MarkOfTheWild extends SpellCard {
@@ -39,16 +40,15 @@ public class MarkOfTheWild extends SpellCard {
 	 * 
 	 * This card heals the target minion up to full health and gives it taunt.  Cannot be used on heroes.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -61,7 +61,7 @@ public class MarkOfTheWild extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setAttack((byte)(targetMinion.getAttack() + 2));
 			targetMinion.setHealth((byte)(targetMinion.getHealth() + 2));

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/MindBlast.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/MindBlast.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class MindBlast extends SpellDamage {
@@ -28,16 +29,15 @@ public class MindBlast extends SpellDamage {
 	 * 
 	 * Deals 5 damage to enemy hero
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -45,10 +45,10 @@ public class MindBlast extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0 || !(targetMinion instanceof Hero)) 
+		if (boardState.data_.getCurrentPlayer() == playerModel || !(targetMinion instanceof Hero))
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		return toRet;
 	}	
 }

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/MindControl.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/MindControl.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class MindControl extends SpellCard {
@@ -38,16 +39,15 @@ public class MindControl extends SpellCard {
 	 * 
 	 * Take control of 1 enemy minion
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -55,14 +55,14 @@ public class MindControl extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetMinion instanceof Hero || targetPlayerIndex == 0) {
+		if (targetMinion instanceof Hero || boardState.data_.getCurrentPlayer() == playerModel) {
 			return null;
 		}
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet.data_.removeMinion(1, targetMinion);
-			toRet.data_.placeMinion(0, targetMinion);
+			toRet.data_.removeMinion(targetMinion);
+			toRet.data_.placeMinion(toRet.data_.getCurrentPlayer(), targetMinion);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/MirrorImage.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/MirrorImage.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.minion.concrete.MirrorImageMinion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class MirrorImage extends SpellCard {
@@ -40,16 +41,15 @@ public class MirrorImage extends SpellCard {
 	 * 
 	 * Summons 2 mirror images
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,24 +57,24 @@ public class MirrorImage extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (!(targetMinion instanceof Hero) || targetPlayerIndex == 1) {
+		if (!(targetMinion instanceof Hero) || boardState.data_.getWaitingPlayer() == playerModel) {
 			return null;
 		}
 		
-		int numMinions = boardState.data_.getNumMinions_p0();
+		int numMinions = boardState.data_.getCurrentPlayer().getNumMinions();
 		if (numMinions >= 7)
 			return null;
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			Minion mi0 = new MirrorImageMinion();
-			Minion placementTarget = toRet.data_.getCharacter_p0(numMinions);
-			toRet = mi0.summonMinion(targetPlayerIndex, placementTarget, toRet, deckPlayer0, deckPlayer1, false);
+			Minion placementTarget = toRet.data_.getCharacter(toRet.data_.getCurrentPlayer(), numMinions);
+			toRet = mi0.summonMinion(playerModel, placementTarget, toRet, deckPlayer0, deckPlayer1, false);
 			
 			if (numMinions < 6) {
 				Minion mi1 = new MirrorImageMinion();
-				Minion placementTarget2 = toRet.data_.getCharacter_p0(numMinions+1);
-				toRet = mi1.summonMinion(targetPlayerIndex, placementTarget2, toRet, deckPlayer0, deckPlayer1, false);
+				Minion placementTarget2 = toRet.data_.getCharacter(toRet.data_.getCurrentPlayer(), numMinions+1);
+				toRet = mi1.summonMinion(playerModel, placementTarget2, toRet, deckPlayer0, deckPlayer1, false);
 			}
 		}		
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/MortalCoil.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/MortalCoil.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -29,16 +30,15 @@ public class MortalCoil extends SpellDamage {
 	 * 
 	 * Deals 1 damage to a minion.  If the damage kills the minion, draw a card.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,7 +57,7 @@ public class MortalCoil extends SpellDamage {
 		this.hasBeenUsed(true);
 		HearthTreeNode toRet = boardState;
 
-		toRet = this.attack(targetPlayerIndex, targetMinion, toRet, deckPlayer0, deckPlayer1);
+		toRet = this.attack(playerModel, targetMinion, toRet, deckPlayer0, deckPlayer1);
 		toRet.data_.setMana_p0(toRet.data_.getMana_p0() - this.mana_);
 		toRet.data_.removeCard_hand(this);
 

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Polymorph.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Polymorph.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.minion.concrete.Sheep;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Polymorph extends SpellCard {
@@ -39,16 +40,15 @@ public class Polymorph extends SpellCard {
 	 * 
 	 * Transform a minion into 1/1 sheep
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -60,12 +60,12 @@ public class Polymorph extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet = targetMinion.silenced(targetPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+			toRet = targetMinion.silenced(playerModel, toRet, deckPlayer0, deckPlayer1);
 			Sheep sheep = new Sheep();
-			toRet = sheep.summonMinion(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, true);
-			boardState.data_.removeMinion(targetPlayerIndex, targetMinion);
+			toRet = sheep.summonMinion(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, true);
+			boardState.data_.removeMinion(targetMinion);
 		}
 
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/PowerWordShield.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/PowerWordShield.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -39,16 +40,15 @@ public class PowerWordShield extends SpellCard {
 	 * 
 	 * Gives a minion +2 health and draw a card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -59,7 +59,7 @@ public class PowerWordShield extends SpellCard {
 		if (targetMinion instanceof Hero) {
 			return null;
 		}
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setHealth((byte)(targetMinion.getHealth() + 2));
 			targetMinion.setMaxHealth((byte)(targetMinion.getMaxHealth() + 2));

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/RockbiterWeapon.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/RockbiterWeapon.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class RockbiterWeapon extends SpellCard {
@@ -37,16 +38,15 @@ public class RockbiterWeapon extends SpellCard {
 	 * 
 	 * Gives a minion +4/+4
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -54,7 +54,7 @@ public class RockbiterWeapon extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
 			targetMinion.setExtraAttackUntilTurnEnd((byte)(3 + targetMinion.getExtraAttackUntilTurnEnd()));
 		

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/SacrificialPact.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/SacrificialPact.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Demon;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class SacrificialPact extends SpellCard {
@@ -38,16 +39,15 @@ public class SacrificialPact extends SpellCard {
 	 * 
 	 * Gives a destroy a demon
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -59,12 +59,10 @@ public class SacrificialPact extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet = toRet.data_.getHero_p0().takeHeal((byte)5, 0, toRet, deckPlayer0, deckPlayer1);
+			toRet = toRet.data_.getCurrentPlayerHero().takeHeal((byte)5, boardState.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1);
 			targetMinion.setHealth((byte)-99);
-//			toRet = targetMinion.destroyed(targetPlayerIndex, toRet, deckPlayer0, deckPlayer1);
-//			toRet.data_.removeMinion(targetPlayerIndex, targetMinion);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/SavageRoar.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/SavageRoar.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class SavageRoar extends SpellCard {
@@ -40,16 +41,15 @@ public class SavageRoar extends SpellCard {
 	 * 
 	 * Gives all friendly characters +2 attack for this turn
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,12 +57,12 @@ public class SavageRoar extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (!(targetMinion instanceof Hero) || targetPlayerIndex == 1) {
+		if (!(targetMinion instanceof Hero) || boardState.data_.getWaitingPlayer() == playerModel) {
 			return null;
 		}
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
-		toRet.data_.getHero_p0().setExtraAttackUntilTurnEnd((byte)2);
-		for (Minion minion : boardState.data_.getMinions_p0())
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		toRet.data_.getCurrentPlayerHero().setExtraAttackUntilTurnEnd((byte)2);
+		for (Minion minion : boardState.data_.getCurrentPlayer().getMinions())
 			minion.setExtraAttackUntilTurnEnd((byte)2);
 		
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/ShadowBolt.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/ShadowBolt.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class ShadowBolt extends SpellDamage {
@@ -29,16 +30,15 @@ public class ShadowBolt extends SpellDamage {
 	 * 
 	 * Cannot be used on the heroes
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -49,6 +49,6 @@ public class ShadowBolt extends SpellDamage {
 		if (targetMinion instanceof Hero) 
 			return null;
 		
-		return super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		return super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 	}
 }

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/ShadowWordDeath.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/ShadowWordDeath.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class ShadowWordDeath extends SpellCard {
@@ -38,16 +39,15 @@ public class ShadowWordDeath extends SpellCard {
 	 * 
 	 * Gives all friendly characters +2 attack for this turn
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -62,7 +62,7 @@ public class ShadowWordDeath extends SpellCard {
 		if (targetMinion.getTotalAttack() < 5)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			targetMinion.setHealth((byte)(-99));
 		}		

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/ShadowWordPain.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/ShadowWordPain.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class ShadowWordPain extends SpellCard {
@@ -38,16 +39,15 @@ public class ShadowWordPain extends SpellCard {
 	 * 
 	 * Gives all friendly characters +2 attack for this turn
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -61,7 +61,7 @@ public class ShadowWordPain extends SpellCard {
 		if (targetMinion.getTotalAttack() > 3)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {		
 			targetMinion.setHealth((byte)(-99));
 		}		

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/ShieldBlock.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/ShieldBlock.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -40,16 +41,15 @@ public class ShieldBlock extends SpellCard {
 	 * 
 	 * Gives all friendly characters +2 attack for this turn
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,13 +57,13 @@ public class ShieldBlock extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (!(targetMinion instanceof Hero) || targetPlayerIndex == 1) {
+		if (!(targetMinion instanceof Hero) || boardState.data_.getWaitingPlayer() == playerModel) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet.data_.getHero_p0().setArmor((byte)(toRet.data_.getHero_p0().getArmor() + 5));
+			toRet.data_.getCurrentPlayerHero().setArmor((byte)(toRet.data_.getCurrentPlayerHero().getArmor() + 5));
 			if (toRet instanceof CardDrawNode) {
 				((CardDrawNode) toRet).addNumCardsToDraw(1);
 			} else {

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Shiv.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Shiv.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -30,16 +31,15 @@ public class Shiv extends SpellDamage {
 	 * 
 	 * Deals 1 damage and draws a card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -47,10 +47,11 @@ public class Shiv extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0 && targetMinion instanceof Hero)
+
+		if (boardState.data_.getCurrentPlayer() == playerModel && targetMinion instanceof Hero)
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet instanceof CardDrawNode) {
 			((CardDrawNode) toRet).addNumCardsToDraw(1);
 		} else {

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Silence.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Silence.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Silence extends SpellCard {
@@ -29,16 +30,15 @@ public class Silence extends SpellCard {
 	 * 
 	 * Deals 1 damage and draws a card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -50,9 +50,9 @@ public class Silence extends SpellCard {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
-			toRet = targetMinion.silenced(targetPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+			toRet = targetMinion.silenced(playerModel, boardState, deckPlayer0, deckPlayer1);
 		return toRet;
 	}
 }

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/SinisterStrike.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/SinisterStrike.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class SinisterStrike extends SpellDamage {
@@ -28,16 +29,15 @@ public class SinisterStrike extends SpellDamage {
 	 * 
 	 * Deals 2 damage and heals the hero for 2.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -45,9 +45,9 @@ public class SinisterStrike extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0 || !(targetMinion instanceof Hero)) 
+		if (boardState.data_.getCurrentPlayer() == playerModel || !(targetMinion instanceof Hero))
 			return null;
 		
-		return super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		return super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 	}
 }

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Slam.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Slam.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -29,16 +30,15 @@ public class Slam extends SpellDamage {
 	 * 
 	 * Deals 2 damage to a minion.  If the target minion survives, draw a card. 
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -49,7 +49,7 @@ public class Slam extends SpellDamage {
 		if (targetMinion instanceof Hero) 
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
         if (toRet != null && targetMinion.getTotalHealth() > 0) {
             if (toRet instanceof CardDrawNode) {
                 ((CardDrawNode) toRet).addNumCardsToDraw(1);

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Sprint.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Sprint.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -40,16 +41,15 @@ public class Sprint extends SpellCard {
 	 * 
 	 * This card draws 4 cards from the deck.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,11 +57,11 @@ public class Sprint extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 1 || !(targetMinion instanceof Hero)) {
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero)) {
 			return null;
 		}
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet instanceof CardDrawNode) {
 			((CardDrawNode) toRet).addNumCardsToDraw(4);
 		} else {

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Starfire.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Starfire.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellDamage;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -29,16 +30,15 @@ public class Starfire extends SpellDamage {
 	 * 
 	 * Deals 5 damage and draws a card
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -46,7 +46,7 @@ public class Starfire extends SpellDamage {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet instanceof CardDrawNode) {
 			((CardDrawNode) toRet).addNumCardsToDraw(1);
 		} else {

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Swipe.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Swipe.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Swipe extends SpellCard {
@@ -39,16 +40,15 @@ public class Swipe extends SpellCard {
 	 * 
 	 * Deals 4 damage to an enemy and 1 damage to all other enemies
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,17 +56,17 @@ public class Swipe extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0) {
+		if (boardState.data_.getCurrentPlayer() == playerModel) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
-		toRet = targetMinion.takeDamage((byte)4, 0, targetPlayerIndex, toRet, deckPlayer0, deckPlayer1, true, false);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		toRet = targetMinion.takeDamage((byte)4, toRet.data_.getCurrentPlayer(), playerModel, toRet, deckPlayer0, deckPlayer1, true, false);
 		if (!(targetMinion instanceof Hero))
-			toRet = toRet.data_.getHero_p1().takeDamage((byte)1, 0, targetPlayerIndex, boardState, deckPlayer0, deckPlayer1, true, false);
-		for (Minion minion : toRet.data_.getMinions_p1()) {
+			toRet = toRet.data_.getWaitingPlayerHero().takeDamage((byte)1, boardState.data_.getCurrentPlayer(), playerModel, boardState, deckPlayer0, deckPlayer1, true, false);
+		for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
 			if (minion != targetMinion)
-				toRet = minion.takeDamage((byte)1, 0, targetPlayerIndex, toRet, deckPlayer0, deckPlayer1, true, false);
+				toRet = minion.takeDamage((byte)1, toRet.data_.getCurrentPlayer(), playerModel, toRet, deckPlayer0, deckPlayer1, true, false);
 		}
 				
 		return toRet;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/TheCoin.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/TheCoin.java
@@ -5,6 +5,8 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 import org.json.JSONObject;
 
@@ -24,8 +26,8 @@ public class TheCoin extends SpellCard {
 	}
 
 	@Override
-    public boolean canBeUsedOn(int playerIndex, Minion minion) {
-		if (playerIndex > 0 || !(minion instanceof Hero))
+    public boolean canBeUsedOn(PlayerModel playerModel, Minion minion, BoardModel boardModel) {
+		if (playerModel == boardModel.getWaitingPlayer() || !(minion instanceof Hero))
 			return false;
 		return true;
 	}
@@ -34,16 +36,15 @@ public class TheCoin extends SpellCard {
 	 * 
 	 * Use the card on the given target
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -51,9 +52,9 @@ public class TheCoin extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (!this.canBeUsedOn(targetPlayerIndex, targetMinion))
+		if (!this.canBeUsedOn(playerModel, targetMinion, boardState.data_))
 			return null;
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			int newMana = toRet.data_.getMana_p0();
 			newMana = newMana >= 10 ? newMana : newMana + 1;

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/TotemicMight.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/TotemicMight.java
@@ -6,6 +6,7 @@ import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.minion.Totem;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class TotemicMight extends SpellCard {
@@ -39,16 +40,15 @@ public class TotemicMight extends SpellCard {
 	 * 
 	 * Gives all friendly totems +2 health
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -56,13 +56,13 @@ public class TotemicMight extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (!(targetMinion instanceof Hero) || targetPlayerIndex == 1) {
+		if (!(targetMinion instanceof Hero) || boardState.data_.getWaitingPlayer() == playerModel) {
 			return null;
 		}
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p0()) {
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
 				if (minion instanceof Totem) {
 					minion.setHealth((byte)(2 + minion.getHealth()));
 					minion.setMaxHealth((byte)(2 + minion.getMaxHealth()));

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Whirlwind.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Whirlwind.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Whirlwind extends SpellCard {
@@ -40,16 +41,15 @@ public class Whirlwind extends SpellCard {
 	 * 
 	 * Deals 3 damage to all characters
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,18 +57,18 @@ public class Whirlwind extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 0 || !(targetMinion instanceof Hero)) 
+		if (boardState.data_.getCurrentPlayer() == playerModel || !(targetMinion instanceof Hero))
 			return null;
 		
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		
 		if (toRet != null) {
-			for (Minion minion : toRet.data_.getMinions_p1()) {
-				toRet = minion.takeDamage(DAMAGE_AMOUNT, 0, 1, toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getWaitingPlayer().getMinions()) {
+				toRet = minion.takeDamage(DAMAGE_AMOUNT, toRet.data_.getCurrentPlayer(), toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 	
-			for (Minion minion : toRet.data_.getMinions_p0()) {
-				toRet = minion.takeDamage(DAMAGE_AMOUNT, 0, 0, toRet, deckPlayer0, deckPlayer1, true, false);
+			for (Minion minion : toRet.data_.getCurrentPlayer().getMinions()) {
+				toRet = minion.takeDamage(DAMAGE_AMOUNT, toRet.data_.getCurrentPlayer(), toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, true, false);
 			}
 		}
 

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/WildGrowth.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/WildGrowth.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class WildGrowth extends SpellCard {
@@ -40,16 +41,15 @@ public class WildGrowth extends SpellCard {
 	 * Gain an empty mana crystal (i.e., it increases maxMana by 1).  If maxMana is already 10, then it places
 	 * the ExcessMana card in your hand.
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -57,14 +57,14 @@ public class WildGrowth extends SpellCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		if (targetPlayerIndex == 1 || !(targetMinion instanceof Hero)) {
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero)) {
 			return null;
 		}
 
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
 			if (toRet.data_.getMaxMana_p0() >= 10) {
-				toRet.data_.placeCard_hand_p0(new ExcessMana());
+				toRet.data_.placeCardHandCurrentPlayer(new ExcessMana());
 			} else {
 				if (toRet.data_.getMaxMana_p0() < 10)
 					toRet.data_.addMaxMana_p0(1);			

--- a/src/main/java/com/hearthsim/card/spellcard/concrete/Windfury.java
+++ b/src/main/java/com/hearthsim/card/spellcard/concrete/Windfury.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.spellcard.SpellCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class Windfury extends SpellCard {
@@ -38,16 +39,15 @@ public class Windfury extends SpellCard {
 	 * 
 	 * Gives a minion windfury
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	@Override
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -58,7 +58,7 @@ public class Windfury extends SpellCard {
 		if (targetMinion instanceof Hero) {
 			return null;
 		}
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null)
 			targetMinion.hasWindFuryAttacked(true);
 		return toRet;

--- a/src/main/java/com/hearthsim/card/weapon/WeaponCard.java
+++ b/src/main/java/com/hearthsim/card/weapon/WeaponCard.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class WeaponCard extends Card {
@@ -65,15 +66,14 @@ public class WeaponCard extends Card {
 	 * 
 	 * This is the core implementation of card's ability
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -85,19 +85,19 @@ public class WeaponCard extends Card {
 			//Card is already used, nothing to do
 			return null;
 		}
-				
-		if (targetPlayerIndex == 1 || !(targetMinion instanceof Hero)) {
+
+		if (boardState.data_.getWaitingPlayer() == playerModel || !(targetMinion instanceof Hero)) {
 			return null;
 		}
 		
 		HearthTreeNode toRet = boardState;
 		if (toRet != null) {
-			toRet.data_.getHero_p0().setAttack(this.weaponDamage_);
-			toRet.data_.getHero_p0().setWeaponCharge(this.weaponCharge_);
+			toRet.data_.getCurrentPlayerHero().setAttack(this.weaponDamage_);
+			toRet.data_.getCurrentPlayerHero().setWeaponCharge(this.weaponCharge_);
 			this.hasBeenUsed(true);
 
 		}
 		
-		return super.use_core(targetPlayerIndex, targetMinion, toRet, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		return super.use_core(playerModel, targetMinion, toRet, deckPlayer0, deckPlayer1, singleRealizationOnly);
 	}
 }

--- a/src/main/java/com/hearthsim/card/weapon/concrete/StormforgedAxe.java
+++ b/src/main/java/com/hearthsim/card/weapon/concrete/StormforgedAxe.java
@@ -4,6 +4,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.card.weapon.WeaponCard;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class StormforgedAxe extends WeaponCard {
@@ -22,15 +23,14 @@ public class StormforgedAxe extends WeaponCard {
 	 * 
 	 * Overload (1)
 	 * 
-	 * @param thisCardIndex The index (position) of the card in the hand
-	 * @param playerIndex The index of the target player.  0 if targeting yourself or your own minions, 1 if targeting the enemy
-	 * @param minionIndex The index of the target minion.
-	 * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
-	 * 
-	 * @return The boardState is manipulated and returned
+	 *
+     * @param playerModel
+     * @param boardState The BoardState before this card has performed its action.  It will be manipulated and returned.
+     *
+     * @return The boardState is manipulated and returned
 	 */
 	protected HearthTreeNode use_core(
-			int targetPlayerIndex,
+			PlayerModel playerModel,
 			Minion targetMinion,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
@@ -38,9 +38,9 @@ public class StormforgedAxe extends WeaponCard {
 			boolean singleRealizationOnly)
 		throws HSException
 	{
-		HearthTreeNode toRet = super.use_core(targetPlayerIndex, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
+		HearthTreeNode toRet = super.use_core(playerModel, targetMinion, boardState, deckPlayer0, deckPlayer1, singleRealizationOnly);
 		if (toRet != null) {
-			toRet.data_.addOverload(targetPlayerIndex, (byte)1);
+			toRet.data_.addOverload(playerModel, (byte)1);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/event/deathrattle/DeathrattleAction.java
+++ b/src/main/java/com/hearthsim/event/deathrattle/DeathrattleAction.java
@@ -3,6 +3,7 @@ package com.hearthsim.event.deathrattle;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 /**
@@ -15,14 +16,13 @@ public abstract class DeathrattleAction {
 	 * Perform the action
 	 * 
 	 * @param minion The minion that is performing the action (aka, the dying minion)
-	 * @param thisPlayerIndex The player index of the dying minion
-	 * @param boardState
-	 * @param deckPlayer0
-	 * @param deckPlayer1
-	 * @return
+	 * @param playerModel
+     *@param boardState
+     * @param deckPlayer0
+     * @param deckPlayer1    @return
 	 * @throws HSInvalidPlayerIndexException
 	 */
-	public HearthTreeNode performAction(Minion minion, int thisPlayerIndex, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
+	public HearthTreeNode performAction(Minion minion, PlayerModel playerModel, HearthTreeNode boardState, Deck deckPlayer0, Deck deckPlayer1) throws HSException {
 		return boardState;
 	}
 	

--- a/src/main/java/com/hearthsim/event/deathrattle/DeathrattleCardDrawAction.java
+++ b/src/main/java/com/hearthsim/event/deathrattle/DeathrattleCardDrawAction.java
@@ -3,6 +3,7 @@ package com.hearthsim.event.deathrattle;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.CardDrawNode;
 import com.hearthsim.util.tree.HearthTreeNode;
 
@@ -17,15 +18,15 @@ public class DeathrattleCardDrawAction extends DeathrattleAction {
 	@Override
 	public HearthTreeNode performAction(
 			Minion minion,
-			int thisPlayerIndex,
+			PlayerModel playerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1) 
 		throws HSException
 	{
-		HearthTreeNode toRet = super.performAction(minion, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.performAction(minion, playerModel, boardState, deckPlayer0, deckPlayer1);
 		if (!minion.isSilenced()) {
-			if (thisPlayerIndex == 0) {
+			if (playerModel == boardState.data_.getCurrentPlayer()) {
 				if (toRet instanceof CardDrawNode) {
 					((CardDrawNode) toRet).addNumCardsToDraw(numCards_);
 				} else {
@@ -33,7 +34,7 @@ public class DeathrattleCardDrawAction extends DeathrattleAction {
 				}
 			} else {
 				//This minion is an enemy minion.  Let's draw a card for the enemy.  No need to use a StopNode for enemy card draws.
-				toRet.data_.drawCardFromDeck_p1(deckPlayer1, numCards_);
+				toRet.data_.drawCardFromWaitingPlayerDeck(deckPlayer1, numCards_);
 			}
 		}
 		return toRet;		

--- a/src/main/java/com/hearthsim/event/deathrattle/DeathrattleDamageAll.java
+++ b/src/main/java/com/hearthsim/event/deathrattle/DeathrattleDamageAll.java
@@ -3,6 +3,7 @@ package com.hearthsim.event.deathrattle;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DeathrattleDamageAll extends DeathrattleAction {
@@ -16,21 +17,21 @@ public class DeathrattleDamageAll extends DeathrattleAction {
 	@Override
 	public HearthTreeNode performAction(
 			Minion minion,
-			int thisPlayerIndex,
+			PlayerModel playerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1) 
 		throws HSException
 	{
-		HearthTreeNode toRet = super.performAction(minion, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.performAction(minion, playerModel, boardState, deckPlayer0, deckPlayer1);
 		if (toRet != null) {
-			toRet = toRet.data_.getHero_p0().takeDamage(damage_, thisPlayerIndex, 0, boardState, deckPlayer0, deckPlayer1, false, false);
-			for(Minion aMinion : toRet.data_.getMinions_p0()) {
-				toRet = aMinion.takeDamage(damage_, thisPlayerIndex, 0, toRet, deckPlayer0, deckPlayer1, false, false);
+			toRet = toRet.data_.getCurrentPlayerHero().takeDamage(damage_, playerModel, toRet.data_.getCurrentPlayer(), boardState, deckPlayer0, deckPlayer1, false, false);
+			for(Minion aMinion : toRet.data_.getCurrentPlayer().getMinions()) {
+				toRet = aMinion.takeDamage(damage_, playerModel, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, false, false);
 			}
-			toRet = toRet.data_.getHero_p1().takeDamage(damage_, thisPlayerIndex, 1, boardState, deckPlayer0, deckPlayer1, false, false);
-			for(Minion aMinion : toRet.data_.getMinions_p1()) {
-				toRet = aMinion.takeDamage(damage_, thisPlayerIndex, 1, toRet, deckPlayer0, deckPlayer1, false, false);
+			toRet = toRet.data_.getWaitingPlayerHero().takeDamage(damage_, playerModel, toRet.data_.getWaitingPlayer(), boardState, deckPlayer0, deckPlayer1, false, false);
+			for(Minion aMinion : toRet.data_.getWaitingPlayer().getMinions()) {
+				toRet = aMinion.takeDamage(damage_, playerModel, toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, false, false);
 			}
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/event/deathrattle/DeathrattleDamageAllMinions.java
+++ b/src/main/java/com/hearthsim/event/deathrattle/DeathrattleDamageAllMinions.java
@@ -3,6 +3,7 @@ package com.hearthsim.event.deathrattle;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DeathrattleDamageAllMinions extends DeathrattleAction {
@@ -16,19 +17,19 @@ public class DeathrattleDamageAllMinions extends DeathrattleAction {
 	@Override
 	public HearthTreeNode performAction(
 			Minion minion,
-			int thisPlayerIndex,
+			PlayerModel playerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1) 
 		throws HSException
 	{
-		HearthTreeNode toRet = super.performAction(minion, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.performAction(minion, playerModel, boardState, deckPlayer0, deckPlayer1);
 		if (toRet != null) {
-			for(Minion aMinion : toRet.data_.getMinions_p1()) {
-				toRet = aMinion.takeDamage(damage_, thisPlayerIndex, 1, toRet, deckPlayer0, deckPlayer1, false, false);
+			for(Minion aMinion : toRet.data_.getWaitingPlayer().getMinions()) {
+				toRet = aMinion.takeDamage(damage_, playerModel, toRet.data_.getWaitingPlayer(), toRet, deckPlayer0, deckPlayer1, false, false);
 			}
-			for(Minion aMinion : toRet.data_.getMinions_p0()) {
-				toRet = aMinion.takeDamage(damage_, thisPlayerIndex, 0, toRet, deckPlayer0, deckPlayer1, false, false);
+			for(Minion aMinion : toRet.data_.getCurrentPlayer().getMinions()) {
+				toRet = aMinion.takeDamage(damage_, playerModel, toRet.data_.getCurrentPlayer(), toRet, deckPlayer0, deckPlayer1, false, false);
 			}
 		}
 		return toRet;

--- a/src/main/java/com/hearthsim/event/deathrattle/DeathrattleDealDamageEnemyHeroAction.java
+++ b/src/main/java/com/hearthsim/event/deathrattle/DeathrattleDealDamageEnemyHeroAction.java
@@ -3,6 +3,7 @@ package com.hearthsim.event.deathrattle;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DeathrattleDealDamageEnemyHeroAction extends DeathrattleAction {
@@ -15,15 +16,16 @@ public class DeathrattleDealDamageEnemyHeroAction extends DeathrattleAction {
 	@Override
 	public HearthTreeNode performAction(
 			Minion minion,
-			int thisPlayerIndex,
+			PlayerModel playerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1) 
 		throws HSException
 	{
-		HearthTreeNode toRet = super.performAction(minion, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.performAction(minion, playerModel, boardState, deckPlayer0, deckPlayer1);
 		if (toRet != null) {
-			toRet = toRet.data_.getHero((thisPlayerIndex + 1) % 2).takeDamage(damage_, thisPlayerIndex, thisPlayerIndex, toRet, deckPlayer0, deckPlayer1, false, false);
+            PlayerModel otherPlayer = boardState.data_.getOtherPlayer(playerModel);
+			toRet = otherPlayer.getHero().takeDamage(damage_, playerModel, playerModel, toRet, deckPlayer0, deckPlayer1, false, false);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/event/deathrattle/DeathrattleHealHeroAction.java
+++ b/src/main/java/com/hearthsim/event/deathrattle/DeathrattleHealHeroAction.java
@@ -3,6 +3,7 @@ package com.hearthsim.event.deathrattle;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DeathrattleHealHeroAction extends DeathrattleAction {
@@ -18,16 +19,17 @@ public class DeathrattleHealHeroAction extends DeathrattleAction {
 	@Override
 	public HearthTreeNode performAction(
 			Minion minion,
-			int thisPlayerIndex,
+			PlayerModel playerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1) 
 		throws HSException
 	{
-		HearthTreeNode toRet = super.performAction(minion, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.performAction(minion, playerModel, boardState, deckPlayer0, deckPlayer1);
 		if (toRet != null) {
-			int targetPlayerIndex = targetEnemyHero_ ? (thisPlayerIndex + 1) % 2 : thisPlayerIndex;
-			toRet = toRet.data_.getHero(targetPlayerIndex).takeHeal(amount_, targetPlayerIndex, toRet, deckPlayer0, deckPlayer1);
+            PlayerModel otherPlayer = boardState.data_.getOtherPlayer(playerModel);
+            PlayerModel targetPlayerModel = targetEnemyHero_ ? otherPlayer : playerModel;
+			toRet = toRet.data_.getHero(targetPlayerModel).takeHeal(amount_, targetPlayerModel, toRet, deckPlayer0, deckPlayer1);
 		}
 		return toRet;
 	}

--- a/src/main/java/com/hearthsim/event/deathrattle/DeathrattleSummonMinionAction.java
+++ b/src/main/java/com/hearthsim/event/deathrattle/DeathrattleSummonMinionAction.java
@@ -3,6 +3,7 @@ package com.hearthsim.event.deathrattle;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 public class DeathrattleSummonMinionAction extends DeathrattleAction {
@@ -18,19 +19,19 @@ public class DeathrattleSummonMinionAction extends DeathrattleAction {
 	@Override
 	public HearthTreeNode performAction(
 			Minion minion,
-			int thisPlayerIndex,
+			PlayerModel playerModel,
 			HearthTreeNode boardState,
 			Deck deckPlayer0,
 			Deck deckPlayer1) 
 		throws HSException
 	{
-		HearthTreeNode toRet = super.performAction(minion, thisPlayerIndex, boardState, deckPlayer0, deckPlayer1);
+		HearthTreeNode toRet = super.performAction(minion, playerModel, boardState, deckPlayer0, deckPlayer1);
 		for (int index = 0; index < numMinions_; ++index) {
             try {
             	Minion newMinion = (Minion)minionClass_.newInstance();
-            	Minion placementTarget = toRet.data_.getCharacter(thisPlayerIndex, toRet.data_.getMinions(thisPlayerIndex).indexOf(minion)); //this minion can't be a hero
-            	toRet.data_.removeMinion(thisPlayerIndex, minion);
-				toRet = newMinion.summonMinion(thisPlayerIndex, placementTarget, toRet, deckPlayer0, deckPlayer1, false);
+            	Minion placementTarget = toRet.data_.getCharacter(playerModel, toRet.data_.getMinions(playerModel).indexOf(minion)); //this minion can't be a hero
+            	toRet.data_.removeMinion(minion);
+				toRet = newMinion.summonMinion(playerModel, placementTarget, toRet, deckPlayer0, deckPlayer1, false);
 			} catch (InstantiationException | IllegalAccessException e) {
 				// TODO Auto-generated catch block
 				throw new HSException();

--- a/src/main/java/com/hearthsim/model/BoardModel.java
+++ b/src/main/java/com/hearthsim/model/BoardModel.java
@@ -1,3 +1,4 @@
+
 package com.hearthsim.model;
 
 import com.hearthsim.card.Card;
@@ -14,8 +15,6 @@ import org.json.JSONObject;
 import org.slf4j.MDC;
 
 import java.util.ArrayList;
-import java.util.Iterator;
-
 
 /**
  * A class that represents the current state of the board (game)
@@ -23,66 +22,82 @@ import java.util.Iterator;
  */
 public class BoardModel implements DeepCopyable {
 
+    //todo: replace all the calls using 'getCurrentPlayer' and 'getWaitingPlayer' with one of these.
+    public enum PlayerSide {
+        CURRENT_PLAYER,
+        WAITING_PLAYER
+    }
+
     private final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
     private PlayerModel currentPlayer;
     private PlayerModel waitingPlayer;
 
-    PlayerModel playerModel0;
-    PlayerModel playerModel1;
-		
-	MinionList p0_minions_;
-	MinionList p1_minions_;
-		
-	IdentityLinkedList<Card> p0_hand_;
-	IdentityLinkedList<Card> p1_hand_;
-	
-	Hero p0_hero_;
-	Hero p1_hero_;
-	
-	int p0_mana_;
-	int p1_mana_;
-	int p0_maxMana_;
-	int p1_maxMana_;
-	
-	int p0_deckPos_;
-	int p1_deckPos_;
-	byte p0_fatigueDamage_;
-	byte p1_fatigueDamage_;
-	
-	byte p0_spellDamage_;
-	byte p1_spellDamage_;
-	
-	byte p0_overload_;
-	byte p1_overload_;
-	
-	IdentityLinkedList<MinionPlayerIDPair> allMinionsFIFOList_;
-	
-	public class MinionPlayerIDPair {
-		public final Minion minion_;
-		public int playerIndex_;
-		
-		public MinionPlayerIDPair(Minion minion, int playerIndex) {
-			minion_ = minion;
-			playerIndex_ = playerIndex;
-		}
-	}
+    int p0_mana_;
+    int p1_mana_;
+    int p0_maxMana_;
+    int p1_maxMana_;
+
+    int p0_deckPos_;
+    int p1_deckPos_;
+    byte p0_fatigueDamage_;
+    byte p1_fatigueDamage_;
+
+    IdentityLinkedList<MinionPlayerPair> allMinionsFIFOList_;
+
+    public class MinionPlayerPair {
+        private Minion minion;
+        private PlayerModel playerModel ;
+
+        public MinionPlayerPair(Minion minion, PlayerModel playerModel) {
+            this.minion = minion;
+            this.playerModel = playerModel;
+        }
+
+        public Minion getMinion() {
+            return minion;
+        }
+
+        public PlayerModel getPlayerModel() {
+            return playerModel;
+        }
+
+        public void setPlayerModel(PlayerModel playerModel) {
+            this.playerModel = playerModel;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            MinionPlayerPair that = (MinionPlayerPair) o;
+
+            if (minion != null ? !minion.equals(that.minion) : that.minion != null) return false;
+            if (playerModel != null ? !playerModel.equals(that.playerModel) : that.playerModel != null) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = minion != null ? minion.hashCode() : 0;
+            result = 31 * result + (playerModel != null ? playerModel.hashCode() : 0);
+            return result;
+        }
+    }
 
     public BoardModel() {
         Hero hero0 = new Hero("hero0", (byte) 30);
         Hero hero1 = new Hero("hero1", (byte) 30);
-        this.playerModel0 = new PlayerModel("player0", hero0, null);
-        this.playerModel1 = new PlayerModel("player1", hero1, null);
 
-        this.currentPlayer = playerModel0;
-        this.waitingPlayer = playerModel1;
+        this.currentPlayer = new PlayerModel("player0", hero0, null);
+        this.waitingPlayer = new PlayerModel("player1", hero1, null);
 
-        buildModel(hero0, hero1);
+        buildModel();
     }
 
     public BoardModel(PlayerModel playerModel0, PlayerModel playerModel1, PlayerModel firstPlayer) {
-        this.playerModel0 = playerModel0;
-        this.playerModel1 = playerModel1;
 
         if (firstPlayer == playerModel0){
             this.currentPlayer = playerModel0;
@@ -92,19 +107,16 @@ public class BoardModel implements DeepCopyable {
             this.waitingPlayer = playerModel0;
         }
 
-
-        buildModel(playerModel0.getHero(), playerModel1.getHero());
+        buildModel();
     }
 
     public BoardModel(Hero p0_hero, Hero p1_hero) {
-        buildModel(p0_hero, p1_hero);
+        this.currentPlayer = new PlayerModel("p0",p0_hero,null);
+        this.waitingPlayer = new PlayerModel("p1",p1_hero,null);
+        buildModel();
     }
 
-    public void buildModel(Hero p0_hero, Hero p1_hero) {
-        p0_minions_ = new MinionList();
-        p1_minions_ = new MinionList();
-        p0_hand_ = new IdentityLinkedList<Card>();
-        p1_hand_ = new IdentityLinkedList<Card>();
+    public void buildModel() {
         p0_mana_ = 0;
         p1_mana_ = 0;
         p0_maxMana_ = 0;
@@ -114,994 +126,796 @@ public class BoardModel implements DeepCopyable {
         p0_fatigueDamage_ = 1;
         p1_fatigueDamage_ = 1;
 
-        p0_hero_ = p0_hero;
-        p1_hero_ = p1_hero;
-
-        allMinionsFIFOList_ = new IdentityLinkedList<MinionPlayerIDPair>();
+        allMinionsFIFOList_ = new IdentityLinkedList<MinionPlayerPair>();
     }
 
-    public MinionList getMinions(int playerIndex) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_minions_;
-		else if (playerIndex == 1)
-			return p1_minions_;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-
-	public MinionList getMinions_p0() {
-		return p0_minions_;
-	}
-	
-	public MinionList getMinions_p1() {
-		return p1_minions_;
-	}
-	
-	public IdentityLinkedList<Card> getCards_hand_p0() {
-		return p0_hand_;
-	}
-
-	public IdentityLinkedList<Card> getCards_hand_p1() {
-		return p1_hand_;
-	}
-	
-	public Minion getMinion(int playerIndex, int index) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_minions_.get(index);
-		else if (playerIndex == 1)
-			return p1_minions_.get(index);
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public Minion getMinion_p0(int index) {
-		return p0_minions_.get(index);
-	}
-	
-	public Minion getMinion_p1(int index) {
-		return p1_minions_.get(index);
-	}
-	
-	public Card getCard_hand(int playerIndex, int index) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_hand_.get(index);
-		else if (playerIndex == 1)
-			return p1_hand_.get(index);
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public Card getCard_hand_p0(int index) {
-		return p0_hand_.get(index);
-	}
-	
-	public Card getCard_hand_p1(int index) {
-		return p1_hand_.get(index);
-	}
-
-	public void setMinions_p0(MinionList minions) {
-		p0_minions_ = minions;
-	}
-	
-	public void setMinions_p1(MinionList minions) {
-		p1_minions_ = minions;
-	}
-	
-	public void setCards_hand_p0(IdentityLinkedList<Card> cards) {
-		p0_hand_ = cards;
-	}
-	
-	public void setCards_hand_p1(IdentityLinkedList<Card> cards) {
-		p1_hand_ = cards;
-	}
-
-	public void setMinion_p0(Minion card, int index) {
-		p0_minions_.set(index, card);
-	}
-	
-	public void setMinion_p1(Minion card, int index) {
-		p1_minions_.set(index, card);
-	}
-	
-	public void setCard_hand(Card card, int index) {
-		p0_hand_.set(index, card);
-	}
-	
-	public Iterator<Minion> getIterator_p0() {
-		return p0_minions_.iterator();
-	}
-	
-	public Iterator<Minion> getIterator_p1() {
-		return p1_minions_.iterator();
-	}
-	
-	public Iterator<Card> getIterator_hand() {
-		return p0_hand_.iterator();
-	}
-	
-	
-	public Minion getCharacter(int playerIndex, int index) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return index == 0 ? p0_hero_ : p0_minions_.get(index - 1);
-		else if (playerIndex == 1)
-			return index == 0 ? p1_hero_ : p1_minions_.get(index - 1);
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public Minion getCharacter_p0(int index) {
-		return index == 0 ? p0_hero_ : p0_minions_.get(index - 1);
-	}
-
-	public Minion getCharacter_p1(int index) {
-		return index == 0 ? p1_hero_ : p1_minions_.get(index - 1);
-	}
-
-	//-----------------------------------------------------------------------------------
-	// Various ways to put a minion onto board
-	//-----------------------------------------------------------------------------------
-	/**
-	 * Place a minion onto the board.  Does not trigger any events.
-	 * 
-	 * This is a function to place a minion on the board.  Use this function only if you
-	 * want no events to be trigger upon placing the minion.
-	 *
-	 * @param minion The minion to be placed on the board.
-	 * @param position The position to place the minion.  The new minion goes to the "left" (lower index) of the postinion index.
-	 * @throws HSInvalidPlayerIndexException 
-	 */
-	public void placeMinion(int playerIndex, Minion minion, int position) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			p0_minions_.add(position, minion);
-		else if (playerIndex == 1) 
-			p1_minions_.add(position, minion);
-		else
-			throw new HSInvalidPlayerIndexException();
-		this.allMinionsFIFOList_.add(new MinionPlayerIDPair(minion, playerIndex));
-		minion.isInHand(false);
-	}
-
-	
-	/**
-	 * Place a minion onto the board.  Does not trigger any events.
-	 * 
-	 * This is a function to place a minion on the board.  Use this function only if you
-	 * want no events to be trigger upon placing the minion.
-	 *
-	 * @param minion The minion to be placed on the board.  The minion is placed on the right-most space.
-	 * @throws HSInvalidPlayerIndexException 
-	 */
-	public void placeMinion(int playerIndex, Minion minion) throws HSInvalidPlayerIndexException {
-		minion.isInHand(false);
-		if (playerIndex == 0)
-			p0_minions_.add(minion);
-		else if (playerIndex == 1)
-			p1_minions_.add(minion);
-		else
-			throw new HSInvalidPlayerIndexException();
-		this.allMinionsFIFOList_.add(new MinionPlayerIDPair(minion, playerIndex));
-	}
-
-	//-----------------------------------------------------------------------------------
-	//-----------------------------------------------------------------------------------
-
-	public void placeCard_hand(int playerIndex, Card card) throws HSInvalidPlayerIndexException {
-		card.isInHand(true);
-		if (playerIndex == 0)
-			p0_hand_.add(card);
-		else if (playerIndex == 1)
-			p1_hand_.add(card);
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public void placeCard_hand_p0(int cardIndex) {
-        Card card = currentPlayer.drawFromDeck(cardIndex);
-        card.isInHand(true);
-		p0_hand_.add(card);
-	}
-
-    public void placeCard_hand_p0(Card card) {
-        card.isInHand(true);
-        p0_hand_.add(card);
+    public MinionList getMinions(PlayerModel playerModel) throws HSInvalidPlayerIndexException {
+        return playerModel.getMinions();
     }
 
-	public void placeCard_hand_p1(int cardIndex) {
-        Card card = waitingPlayer.drawFromDeck(cardIndex);
-		card.isInHand(true);
-		p1_hand_.add(card);
-	}
 
-    public void placeCard_hand_p1(Card card) {
-        card.isInHand(true);
-        p1_hand_.add(card);
+    public IdentityLinkedList<Card> getCurrentPlayerHand() {
+        return currentPlayer.getHand();
     }
-	
-	public void removeCard_hand(Card card) {
-		p0_hand_.remove(card);
-	}
 
-	public int getNumMinions(int playerIndex) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_minions_.size();
-		else if (playerIndex == 1)
-			return p1_minions_.size();
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
+    public IdentityLinkedList<Card> getWaitingPlayerHand() {
+        return waitingPlayer.getHand();
+    }
 
-	public int getNumMinions_p0() {
-		return p0_minions_.size();
-	}
-	
-	public int getNumMinions_p1() {
-		return p1_minions_.size();
-	}
-	
-	public int getNumCards_hand() {
-		return p0_hand_.size();
-	}
+    public Minion getMinion(PlayerModel playerModel, int index) throws HSInvalidPlayerIndexException {
+        return playerModel.getMinions().get(index);
+    }
 
-	public int getNumCards_hand(int playerIndex) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_hand_.size();
-		else if (playerIndex == 1)
-			return p1_hand_.size();
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
+    public Card getCard_hand(PlayerModel playerModel, int index) throws HSInvalidPlayerIndexException {
+        return playerModel.getHand().get(index);
+    }
 
-	public int getNumCards_hand_p0() {
-		return p0_hand_.size();
-	}
+    public Card getCurrentPlayerCardHand(int index) {
+        return currentPlayer.getHand().get(index);
+    }
 
-	public int getNumCards_hand_p1() {
-		return p1_hand_.size();
-	}
+    public Card getWaitingPlayerCardHand(int index) {
+        return waitingPlayer.getHand().get(index);
+    }
 
-	public Hero getHero(int playerIndex) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_hero_;
-		else if (playerIndex == 1)
-			return p1_hero_;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public Hero getHero_p0() {
-		return p0_hero_;
-	}
-		
-	public Hero getHero_p1() {
-		return p1_hero_;
-	}
-	
-	public void setHero_p0(Hero hero) {
-		p0_hero_ = hero;
-	}
-	
-	public void setHero_p1(Hero hero) {
-		p1_hero_ = hero;
-	}
+    public Minion getCharacter(PlayerModel playerModel, int index) throws HSInvalidPlayerIndexException {
+        return index == 0 ? playerModel.getHero() : playerModel.getMinions().get(index - 1);
+    }
 
-	public int getMana(int playerIndex) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_mana_;
-		else if (playerIndex == 1) 
-			return p1_mana_;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public void setMana(int playerIndex, int mana) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			p0_mana_ = mana;
-		else if (playerIndex == 1) 
-			p1_mana_ = mana;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public int getMana_p0() {
-		return p0_mana_;
-	}
-	
-	public void setMana_p0(int mana) {
-		p0_mana_ = mana;
-	}
-	
-	public int getMana_p1() {
-		return p1_mana_;
-	}
-	
-	public void setMana_p1(int mana) {
-		p1_mana_ = mana;
-	}
+    public Minion getCurrentPlayerCharacter(int index) {
+        return getMinionForCharacter(currentPlayer, index);
+    }
 
-	public int getMaxMana_p0() {
-		return p0_maxMana_;
-	}
-	
-	public void setMaxMana_p0(int mana) {
-		p0_maxMana_ = mana;
-	}
-	
-	public int getMaxMana_p1() {
-		return p1_maxMana_;
-	}
-	
-	public void setMaxMana_p1(int mana) {
-		p1_maxMana_ = mana;
-	}
-	
-	public void addMaxMana_p0(int mana) {
-		p0_maxMana_ += mana;
-	}
-	
-	public void addMaxMana_p1(int mana) {
-		p1_maxMana_ += mana;
-	}
-	
-	public void addMana(int playerIndex, int mana) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			p0_mana_ += mana;
-		else if (playerIndex == 1) 
-			p1_mana_ += mana;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public void addMana_p0(int mana) {
-		p0_mana_ += mana;
-	}
+    public Minion getWaitingPlayerCharacter(int index) {
+        return getMinionForCharacter(waitingPlayer, index);
+    }
 
-	public void addMana_p1(int mana) {
-		p1_mana_ += mana;
-	}
+    public Minion getMinionForCharacter(PlayerModel playerModel, int index) {
+        return index == 0 ? playerModel.getHero() : playerModel.getMinions().get(index - 1);
+    }
 
-	/**
-	 * Index of the next card in deck
-	 * 
-	 * Returns the index of the next card to draw from the deck.
-	 * @return
-	 */
-	public int getDeckPos(int playerIndex) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_deckPos_;
-		else if (playerIndex == 1)
-			return p1_deckPos_;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public void setDeckPos(int playerIndex, int position) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			p0_deckPos_ = position;
-		else if (playerIndex == 1)
-			p1_deckPos_ = position;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	/**
-	 * Index of the next card in deck
-	 * 
-	 * Returns the index of the next card to draw from the deck.
-	 * @return
-	 */
-	public int getDeckPos_p0() {
-		return p0_deckPos_;
-	}
-	
-	public void setDeckPos_p0(int position) {
-		p0_deckPos_ = position;
-	}
-	
-	/**
-	 * Index of the next card in deck
-	 * 
-	 * Returns the index of the next card to draw from the deck.
-	 * @return
-	 */
-	public int getDeckPos_p1() {
-		return p1_deckPos_;
-	}
-	
-	public void setDeckPos_p1(int position) {
-		p1_deckPos_ = position;
-	}
+    //-----------------------------------------------------------------------------------
+    // Various ways to put a minion onto board
+    //-----------------------------------------------------------------------------------
+    /**
+     * Place a minion onto the board.  Does not trigger any events.
+     *
+     * This is a function to place a minion on the board.  Use this function only if you
+     * want no events to be trigger upon placing the minion.
+     *
+     *
+     * @param playerIndex
+     * @param minion The minion to be placed on the board.
+     * @param position The position to place the minion.  The new minion goes to the "left" (lower index) of the postinion index.
+     * @throws HSInvalidPlayerIndexException
+     */
+    public void placeMinion(PlayerModel playerModel, Minion minion, int position) throws HSInvalidPlayerIndexException {
+        playerModel.getMinions().add(position, minion);
 
-	/**
-	 * Draw a card from a deck and place it in the hand
-	 * 
-	 * This function is intentionally only implemented for Player1.  
-	 * For Player0, it is almost always correct to user CardDrawNode instead.
-	 * 
-	 * @param deck Deck from which to draw.
-	 * @param numCards Number of cards to draw.
-	 * @throws HSInvalidPlayerIndexException
-	 */
-	public void drawCardFromDeck_p1(Deck deck, int numCards) throws HSInvalidPlayerIndexException {
-		//This minion is an enemy minion.  Let's draw a card for the enemy.  No need to use a StopNode for enemy card draws.
-		for (int indx = 0; indx < numCards; ++indx) {
-			Card card = deck.drawCard(this.getDeckPos(1));
-			if (card == null) {
-				byte fatigueDamage = this.getFatigueDamage(1);
-				this.setFatigueDamage(1, (byte)(fatigueDamage + 1));
-				this.getHero(1).setHealth((byte)(this.getHero(1).getHealth() - fatigueDamage));
-			} else {
-				if (this.getNumCards_hand_p1() < 10) {
-					this.placeCard_hand(1, card);
-				}
-				this.setDeckPos(1, this.getDeckPos(1) + 1);
-			}
-		}
-	}
-	
-
-	/**
-	 * Get the fatigue damage
-	 * 
-	 * Returns the fatigue damage taken when a card draw fails next.
-	 * @return
-	 */
-	public byte getFatigueDamage(int playerIndex) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_fatigueDamage_;
-		else if (playerIndex == 1) 
-			return p1_fatigueDamage_;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public void setFatigueDamage(int playerIndex, byte damage) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			p0_fatigueDamage_ = damage;
-		else if (playerIndex == 1)
-			p1_fatigueDamage_ = damage;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	/**
-	 * Get the fatigue damage for player 0
-	 * 
-	 * Returns the fatigue damage taken when a card draw fails next.
-	 * @return
-	 */
-	public byte getFatigueDamage_p0() {
-		return p0_fatigueDamage_;
-	}
-	
-	public void setFatigueDamage_p0(byte damage) {
-		p0_fatigueDamage_ = damage;
-	}
-	
-	/**
-	 * Get the fatigue damage for player 1
-	 * 
-	 * Returns the fatigue damage taken when a card draw fails next.
-	 * @return
-	 */
-	public byte getFatigueDamage_p1() {
-		return p1_fatigueDamage_;
-	}
-	
-	public void setFatigueDamage_p1(byte damage) {
-		p1_fatigueDamage_ = damage;
-	}
-	
-	/**
-	 * Get the spell damage
-	 * 
-	 * Returns the additional spell damage provided by buffs
-	 * @return
-	 */
-	public byte getSpellDamage(int playerIndex) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			return p0_spellDamage_;
-		else if (playerIndex == 1) 
-			return p1_spellDamage_;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	/**
-	 * Set the spell damage
-	 * 
-	 * Returns the additional spell damage provided by buffs
-	 * @return
-	 */
-	public void setSpellDamage(int playerIndex, byte damage) throws HSInvalidPlayerIndexException {
-		if (playerIndex == 0)
-			p0_spellDamage_ = damage;
-		else if (playerIndex == 1)
-			p1_spellDamage_ = damage;
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
+        if (!playerModel.equals(currentPlayer) && !(playerModel.equals(waitingPlayer)))
+            throw new RuntimeException("WAHAHSKDLA");
+        this.allMinionsFIFOList_.add(new MinionPlayerPair(minion, playerModel));
+        minion.isInHand(false);
+    }
 
 
-	
-	public boolean removeMinion(MinionPlayerIDPair minionIdPair) throws HSInvalidPlayerIndexException {
-		this.allMinionsFIFOList_.remove(minionIdPair);
-		if (minionIdPair.playerIndex_ == 0)
-			return p0_minions_.remove(minionIdPair.minion_);
-		else if (minionIdPair.playerIndex_ == 1)
-			return p1_minions_.remove(minionIdPair.minion_);
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
+    /**
+     * Place a minion onto the board.  Does not trigger any events.
+     *
+     * This is a function to place a minion on the board.  Use this function only if you
+     * want no events to be trigger upon placing the minion.
+     *
+     *
+     * @param playerModel
+     * @param minion The minion to be placed on the board.  The minion is placed on the right-most space.
+     * @throws HSInvalidPlayerIndexException
+     */
+    public void placeMinion(PlayerModel playerModel, Minion minion) throws HSInvalidPlayerIndexException {
+        minion.isInHand(false);
+        playerModel.getMinions().add(minion);
+        if (!playerModel.equals(currentPlayer) && !(playerModel.equals(waitingPlayer)))
+            throw new RuntimeException("WAHAHSKDLA");
+        this.allMinionsFIFOList_.add(new MinionPlayerPair(minion, playerModel));
+    }
 
-	public boolean removeMinion(int playerIndex, Minion minion) throws HSException {
-		MinionPlayerIDPair mP = null;
-		for (MinionPlayerIDPair minionIdPair : this.allMinionsFIFOList_) {
-			if (minionIdPair.minion_ == minion) {
-				mP = minionIdPair;
-				break;
-			}
-		}
-		this.allMinionsFIFOList_.remove(mP);
-		if (mP.playerIndex_ == 0)
-			return p0_minions_.remove(mP.minion_);
-		else if (mP.playerIndex_ == 1)
-			return p1_minions_.remove(mP.minion_);
-		else
-			throw new HSInvalidPlayerIndexException();
-	}
-	
-	public boolean removeMinion(int playerIndex, int minionIndex) throws HSException {
-		return removeMinion(playerIndex, this.getMinion(playerIndex, minionIndex));
-	}
+    //-----------------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------------
 
-	//----------------------------------------------------------------------------
-	//----------------------------------------------------------------------------
-	// Overload support
-	//----------------------------------------------------------------------------
-	//----------------------------------------------------------------------------
+    public void placeCard_hand(PlayerModel playerModel, Card card) throws HSInvalidPlayerIndexException {
+        card.isInHand(true);
+        playerModel.getHand().add(card);
+    }
 
-	public void addOverload(int playerIndex, byte overloadToAdd) throws HSException {
-		if (playerIndex == 0) {
-			p0_overload_ += overloadToAdd;
-		} else if (playerIndex == 1) {
-			p1_overload_ += overloadToAdd;
-		} else {
-			throw new HSInvalidPlayerIndexException();
-		}
-	}
-	
-	//----------------------------------------------------------------------------
-	//----------------------------------------------------------------------------
-	//----------------------------------------------------------------------------
-	//----------------------------------------------------------------------------
-	
-	
-	public boolean isAlive_p0() {
-		return p0_hero_.getHealth() > 0;
-	}
-	
-	public boolean isAlive_p1() {
-		return p1_hero_.getHealth() > 0;
-	}
-	
-	public ArrayList<Integer> getAttackableMinions_p1() {
-		ArrayList<Integer> toRet = new ArrayList<Integer>();
-		boolean hasTaunt = false;
-		for (final Minion minion : p1_minions_) {
-			hasTaunt = hasTaunt || minion.getTaunt();
-		}
-		if (!hasTaunt) {
-			toRet.add((Integer)0);
-			int counter = 1;
-			for (Iterator<Minion> iter = p1_minions_.iterator(); iter.hasNext(); iter.next()) {
-				toRet.add((Integer)counter);
-				counter++;
-			}
-			return toRet;
-		} else {
-			int counter = 1;
-            for (Minion aP1_minions_ : p1_minions_) {
+    public void placeCardHandCurrentPlayer(int cardIndex) {
+        currentPlayer.placeCardHand(cardIndex);
+    }
+
+    public void placeCardHandCurrentPlayer(Card card) {
+        currentPlayer.placeCardHand(card);
+    }
+
+    public void placeCardHandWaitingPlayer(int cardIndex) {
+        waitingPlayer.placeCardHand(cardIndex);
+    }
+
+    public void placeCardHandWaitingPlayer(Card card) {
+        waitingPlayer.placeCardHand(card);
+    }
+
+    public void removeCard_hand(Card card) {
+        currentPlayer.getHand().remove(card);
+    }
+
+    public int getNumCards_hand() {
+        return currentPlayer.getHand().size();
+    }
+
+    public int getNumCards_hand(PlayerModel playerModel) throws HSInvalidPlayerIndexException {
+        return playerModel.getHand().size();
+    }
+
+    public int getNumCardsHandCurrentPlayer() {
+        return currentPlayer.getHand().size();
+    }
+
+    public int getNumCardsHandWaitingPlayer() {
+        return waitingPlayer.getHand().size();
+    }
+
+    public Hero getHero(PlayerModel playerModel) throws HSInvalidPlayerIndexException {
+        return playerModel.getHero();
+    }
+
+    public Hero getCurrentPlayerHero() {
+        return currentPlayer.getHero();
+    }
+
+    public Hero getWaitingPlayerHero() {
+        return waitingPlayer.getHero();
+    }
+
+    public int getMana_p0() {
+        return p0_mana_;
+    }
+
+    public void setMana_p0(int mana) {
+        p0_mana_ = mana;
+    }
+
+    public int getMana_p1() {
+        return p1_mana_;
+    }
+
+    public void setMana_p1(int mana) {
+        p1_mana_ = mana;
+    }
+
+    public int getMaxMana_p0() {
+        return p0_maxMana_;
+    }
+
+    public void setMaxMana_p0(int mana) {
+        p0_maxMana_ = mana;
+    }
+
+    public int getMaxMana_p1() {
+        return p1_maxMana_;
+    }
+
+    public void setMaxMana_p1(int mana) {
+        p1_maxMana_ = mana;
+    }
+
+    public void addMaxMana_p0(int mana) {
+        p0_maxMana_ += mana;
+    }
+
+    public void addMaxMana_p1(int mana) {
+        p1_maxMana_ += mana;
+    }
+
+    public void addMana_p1(int mana) {
+        p1_mana_ += mana;
+    }
+
+    /**
+     * Index of the next card in deck
+     *
+     * Returns the index of the next card to draw from the deck.
+     * @return
+     */
+    public int getDeckPos(int playerIndex) throws HSInvalidPlayerIndexException {
+        if (playerIndex == 0)
+            return p0_deckPos_;
+        else if (playerIndex == 1)
+            return p1_deckPos_;
+        else
+            throw new HSInvalidPlayerIndexException();
+    }
+
+    public void setDeckPos(int playerIndex, int position) throws HSInvalidPlayerIndexException {
+        if (playerIndex == 0)
+            p0_deckPos_ = position;
+        else if (playerIndex == 1)
+            p1_deckPos_ = position;
+        else
+            throw new HSInvalidPlayerIndexException();
+    }
+
+    /**
+     * Index of the next card in deck
+     *
+     * Returns the index of the next card to draw from the deck.
+     * @return
+     */
+    public int getDeckPos_p0() {
+        return p0_deckPos_;
+    }
+
+    public void setDeckPos_p0(int position) {
+        p0_deckPos_ = position;
+    }
+
+    /**
+     * Index of the next card in deck
+     *
+     * Returns the index of the next card to draw from the deck.
+     * @return
+     */
+    public int getDeckPos_p1() {
+        return p1_deckPos_;
+    }
+
+    public void setDeckPos_p1(int position) {
+        p1_deckPos_ = position;
+    }
+
+    /**
+     * Draw a card from a deck and place it in the hand
+     *
+     * This function is intentionally only implemented for Player1.
+     * For Player0, it is almost always correct to user CardDrawNode instead.
+     *
+     * @param deck Deck from which to draw.
+     * @param numCards Number of cards to draw.
+     * @throws HSInvalidPlayerIndexException
+     */
+    public void drawCardFromWaitingPlayerDeck(Deck deck, int numCards) throws HSInvalidPlayerIndexException {
+        //This minion is an enemy minion.  Let's draw a card for the enemy.  No need to use a StopNode for enemy card draws.
+        for (int indx = 0; indx < numCards; ++indx) {
+            Card card = deck.drawCard(this.getDeckPos(1));
+            if (card == null) {
+                byte fatigueDamage = this.getFatigueDamage(1);
+                this.setFatigueDamage(1, (byte)(fatigueDamage + 1));
+                Hero waitingPlayerHero = this.getWaitingPlayer().getHero();
+                waitingPlayerHero.setHealth((byte) (waitingPlayerHero.getHealth() - fatigueDamage));
+            } else {
+                if (this.getNumCardsHandWaitingPlayer() < 10) {
+                    this.placeCard_hand(waitingPlayer, card);
+                }
+                this.setDeckPos(1, this.getDeckPos(1) + 1);
+            }
+        }
+    }
+
+    /**
+     * Get the fatigue damage
+     *
+     * Returns the fatigue damage taken when a card draw fails next.
+     * @return
+     */
+    public byte getFatigueDamage(int playerIndex) throws HSInvalidPlayerIndexException {
+        if (playerIndex == 0)
+            return p0_fatigueDamage_;
+        else if (playerIndex == 1)
+            return p1_fatigueDamage_;
+        else
+            throw new HSInvalidPlayerIndexException();
+    }
+
+    public void setFatigueDamage(int playerIndex, byte damage) throws HSInvalidPlayerIndexException {
+        if (playerIndex == 0)
+            p0_fatigueDamage_ = damage;
+        else if (playerIndex == 1)
+            p1_fatigueDamage_ = damage;
+        else
+            throw new HSInvalidPlayerIndexException();
+    }
+
+    /**
+     * Get the fatigue damage for player 0
+     *
+     * Returns the fatigue damage taken when a card draw fails next.
+     * @return
+     */
+    public byte getFatigueDamage_p0() {
+        return p0_fatigueDamage_;
+    }
+
+    public void setFatigueDamage_p0(byte damage) {
+        p0_fatigueDamage_ = damage;
+    }
+
+
+    /**
+     * Get the spell damage
+     *
+     * Returns the additional spell damage provided by buffs
+     * @return
+     * @param playerModel
+     */
+    public byte getSpellDamage(PlayerModel playerModel) throws HSInvalidPlayerIndexException {
+        return playerModel.getSpellDamage();
+    }
+
+    /**
+     * Set the spell damage
+     *
+     * Returns the additional spell damage provided by buffs
+     * @return
+     */
+    public void setSpellDamage(PlayerModel playerModel, byte damage) throws HSInvalidPlayerIndexException {
+        playerModel.setSpellDamage(damage);
+    }
+
+
+    public boolean removeMinion(MinionPlayerPair minionIdPair) throws HSInvalidPlayerIndexException {
+        this.allMinionsFIFOList_.remove(minionIdPair);
+        return minionIdPair.getPlayerModel().getMinions().remove(minionIdPair.minion);
+    }
+
+    public boolean removeMinion(Minion minion) throws HSException {
+        MinionPlayerPair mP = null;
+        for (MinionPlayerPair minionIdPair : this.allMinionsFIFOList_) {
+            if (minionIdPair.minion == minion) {
+                mP = minionIdPair;
+                break;
+            }
+        }
+        this.allMinionsFIFOList_.remove(mP);
+        return mP.getPlayerModel().getMinions().remove(mP.minion);
+    }
+
+    public boolean removeMinion(PlayerModel playerModel, int minionIndex) throws HSException {
+        return removeMinion(getMinion(playerModel, minionIndex));
+    }
+
+    //----------------------------------------------------------------------------
+    //----------------------------------------------------------------------------
+    // Overload support
+    //----------------------------------------------------------------------------
+    //----------------------------------------------------------------------------
+
+    public void addOverload(PlayerModel playerModel, byte overloadToAdd) throws HSException {
+        playerModel.setOverload((byte) (currentPlayer.getOverload() + overloadToAdd));
+    }
+
+    //----------------------------------------------------------------------------
+    //----------------------------------------------------------------------------
+    //----------------------------------------------------------------------------
+    //----------------------------------------------------------------------------
+
+
+    public boolean isAlive(PlayerModel playerModel) {
+        return playerModel.getHero().getHealth() > 0;
+    }
+
+    public ArrayList<Integer> getAttackableMinions() {
+        ArrayList<Integer> toRet = new ArrayList<Integer>();
+        boolean hasTaunt = false;
+        for (final Minion minion : waitingPlayer.getMinions()) {
+            hasTaunt = hasTaunt || minion.getTaunt();
+        }
+        if (!hasTaunt) {
+            toRet.add(0);
+            int counter = 1;
+            for (Minion ignored : waitingPlayer.getMinions()) {
+                toRet.add(counter);
+                counter++;
+            }
+            return toRet;
+        } else {
+            int counter = 1;
+            for (Minion aP1_minions_ : waitingPlayer.getMinions()) {
                 if (aP1_minions_.getTaunt())
                     toRet.add(counter);
                 counter++;
             }
-			return toRet;
-		}
-	}
-	
-	
-	//Dead minion check
-	
-	/**
-	 * Checks to see if there are dead minions
-	 * @return
-	 */
-	public boolean hasDeadMinions() {
-		for (Minion minion : p0_minions_) {
-			if (minion.getTotalHealth() <= 0)
-				return true;
-		}
-		for (Minion minion : p1_minions_) {
-			if (minion.getTotalHealth() <= 0) {
-				return true;
-			}
-		}
-		return false;
-	}
-	
+            return toRet;
+        }
+    }
 
-	public IdentityLinkedList<MinionPlayerIDPair> getAllMinionsFIFOList() {
-		return allMinionsFIFOList_;
-	}
-	
-	public void resetMana() {
-		p0_mana_ = p0_maxMana_;
-		p1_mana_ = p1_maxMana_;
-		
-		//handle the overload
-		p0_mana_ -= p0_overload_;
-		p1_mana_ -= p1_overload_;
-		
-		p0_overload_ = 0;
-		p1_overload_ = 0;
-	}
-	
-	public void endTurn(Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
-		p0_hero_.endTurn(0, this, deckPlayer0, deckPlayer1);
-		p1_hero_.endTurn(1, this, deckPlayer0, deckPlayer1);
-		for (int index = 0; index < p0_minions_.size(); ++index) {
-			Minion targetMinion = p0_minions_.get(index);
-			try {
-				targetMinion.endTurn(0, this, deckPlayer0, deckPlayer1);
-			} catch (HSException e) {
-				e.printStackTrace();
-			}
-		}
-		for (int index = 0; index < p1_minions_.size(); ++index) {
-			Minion targetMinion = p1_minions_.get(index);
-			try {
-				targetMinion.endTurn(1, this, deckPlayer0, deckPlayer1);
-			} catch (HSException e) {
-				e.printStackTrace();
-			}
-		}
-		
-		ArrayList<Minion> toRemove = new ArrayList<Minion>();
-		for (Minion targetMinion : p0_minions_) {
-			if (targetMinion.getTotalHealth() <= 0)
-				toRemove.add(targetMinion);
-		}
-		for (Minion minion : toRemove) 
-			p0_minions_.remove(minion);
 
-		toRemove.clear();
-		for (Minion targetMinion : p1_minions_) {
-			if (targetMinion.getTotalHealth() <= 0)
-				toRemove.add(targetMinion);
-		}
-		for (Minion minion : toRemove) 
-			p1_minions_.remove(minion);
-	}
-	
-	public void startTurn() throws HSException {
-		this.resetHand();
-		this.resetMinions();
+    //Dead minion check
 
-		for (Minion targetMinion : p0_minions_) {
-			try {
-				targetMinion.startTurn(0, this, currentPlayer.getDeck(), waitingPlayer.getDeck());
-			} catch (HSInvalidPlayerIndexException e) {
-				e.printStackTrace();
-			}
-		}
-		for (Minion targetMinion : p1_minions_) {
-			try {
-				targetMinion.startTurn(1, this, currentPlayer.getDeck(), waitingPlayer.getDeck());
-			} catch (HSInvalidPlayerIndexException e) {
-				e.printStackTrace();
-			}
-		}
-		ArrayList<Minion> toRemove = new ArrayList<Minion>();
-		for (Minion targetMinion : p0_minions_) {
-			if (targetMinion.getTotalHealth() <= 0)
-				toRemove.add(targetMinion);
-		}
-		for (Minion minion : toRemove) 
-			p0_minions_.remove(minion);
+    /**
+     * Checks to see if there are dead minions
+     * @return
+     */
+    public boolean hasDeadMinions() {
+        for (Minion minion : currentPlayer.getMinions()) {
+            if (minion.getTotalHealth() <= 0)
+                return true;
+        }
+        for (Minion minion : getWaitingPlayer().getMinions()) {
+            if (minion.getTotalHealth() <= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-		toRemove.clear();
-		for (Minion targetMinion : p1_minions_) {
-			if (targetMinion.getTotalHealth() <= 0)
-				toRemove.add(targetMinion);
-		}
-		for (Minion minion : toRemove) 
-			p1_minions_.remove(minion);
-	}
-	
-	public boolean equals(Object other)
-	{
-	   if (other == null)
-	   {
-	      return false;
-	   }
+    public IdentityLinkedList<MinionPlayerPair> getAllMinionsFIFOList() {
+        return allMinionsFIFOList_;
+    }
 
-	   if (this.getClass() != other.getClass())
-	   {
-	      return false;
-	   }
-	   
-	   if (p0_mana_ != ((BoardModel)other).p0_mana_)
-		   return false;
-	   if (p1_mana_ != ((BoardModel)other).p1_mana_)
-		   return false;
-	   if (p0_maxMana_ != ((BoardModel)other).p0_maxMana_)
-		   return false;
-	   if (p1_maxMana_ != ((BoardModel)other).p1_maxMana_)
-		   return false;
-	   
-	   if (!p0_hero_.equals(((BoardModel)other).p0_hero_)) {
-		   return false;
-	   }
+    public void resetMana() {
+        p0_mana_ = p0_maxMana_;
+        p1_mana_ = p1_maxMana_;
 
-	   if (!p1_hero_.equals(((BoardModel)other).p1_hero_)) {
-		   return false;
-	   }
-	   
-	   if (p0_deckPos_ != ((BoardModel)other).p0_deckPos_)
-		   return false;
+        //handle the overload
+        p0_mana_ -= currentPlayer.getOverload();
+        p1_mana_ -= waitingPlayer.getOverload();
 
-	   if (p1_deckPos_ != ((BoardModel)other).p1_deckPos_)
-		   return false;
+        currentPlayer.setOverload((byte) 0);
+        waitingPlayer.setOverload((byte) 0);
+    }
 
-	   if (p0_fatigueDamage_ != ((BoardModel)other).p0_fatigueDamage_)
-		   return false;
-	   
-	   if (p1_fatigueDamage_ != ((BoardModel)other).p1_fatigueDamage_)
-		   return false;
+    public void endTurn(Deck deckPlayer0, Deck deckPlayer1) throws HSInvalidPlayerIndexException {
+        currentPlayer.getHero().endTurn(currentPlayer, this, deckPlayer0, deckPlayer1);
+        waitingPlayer.getHero().endTurn(waitingPlayer, this, deckPlayer0, deckPlayer1);
+        for (int index = 0; index < currentPlayer.getMinions().size(); ++index) {
+            Minion targetMinion = currentPlayer.getMinions().get(index);
+            try {
+                targetMinion.endTurn(currentPlayer, this, deckPlayer0, deckPlayer1);
+            } catch (HSException e) {
+                e.printStackTrace();
+            }
+        }
+        for (int index = 0; index < waitingPlayer.getMinions().size(); ++index) {
+            Minion targetMinion = waitingPlayer.getMinions().get(index);
+            try {
+                targetMinion.endTurn(waitingPlayer, this, deckPlayer0, deckPlayer1);
+            } catch (HSException e) {
+                e.printStackTrace();
+            }
+        }
 
-	   if (p0_spellDamage_ != ((BoardModel)other).p0_spellDamage_)
-		   return false;
+        ArrayList<Minion> toRemove = new ArrayList<Minion>();
+        for (Minion targetMinion : currentPlayer.getMinions()) {
+            if (targetMinion.getTotalHealth() <= 0)
+                toRemove.add(targetMinion);
+        }
+        for (Minion minion : toRemove)
+            currentPlayer.getMinions().remove(minion);
 
-	   if (p1_spellDamage_ != ((BoardModel)other).p1_spellDamage_)
-		   return false;
+        toRemove.clear();
+        for (Minion targetMinion : waitingPlayer.getMinions()) {
+            if (targetMinion.getTotalHealth() <= 0)
+                toRemove.add(targetMinion);
+        }
+        for (Minion minion : toRemove)
+            waitingPlayer.getMinions().remove(minion);
+    }
 
-	   if (p0_minions_.size() != ((BoardModel)other).p0_minions_.size())
-		   return false;
-	   if (p1_minions_.size() != ((BoardModel)other).p1_minions_.size())
-		   return false;
-	   if (p0_hand_.size() != ((BoardModel)other).p0_hand_.size())
-		   return false;
+    public void startTurn() throws HSException {
+        this.resetHand();
+        this.resetMinions();
 
-	   for (int i = 0; i < p0_minions_.size(); ++i) {
-		   if (!p0_minions_.get(i).equals(((BoardModel)other).p0_minions_.get(i))) {
-			   return false;
-		   }
-	   }
+        for (Minion targetMinion : currentPlayer.getMinions()) {
+            try {
+                targetMinion.startTurn(currentPlayer, this, currentPlayer.getDeck(), waitingPlayer.getDeck());
+            } catch (HSInvalidPlayerIndexException e) {
+                e.printStackTrace();
+            }
+        }
+        for (Minion targetMinion : waitingPlayer.getMinions()) {
+            try {
+                targetMinion.startTurn(waitingPlayer, this, currentPlayer.getDeck(), waitingPlayer.getDeck());
+            } catch (HSInvalidPlayerIndexException e) {
+                e.printStackTrace();
+            }
+        }
+        ArrayList<Minion> toRemove = new ArrayList<Minion>();
+        for (Minion targetMinion : currentPlayer.getMinions()) {
+            if (targetMinion.getTotalHealth() <= 0)
+                toRemove.add(targetMinion);
+        }
+        for (Minion minion : toRemove)
+            currentPlayer.getMinions().remove(minion);
 
-	   for (int i = 0; i < p1_minions_.size(); ++i) {
-		   if (!p1_minions_.get(i).equals(((BoardModel)other).p1_minions_.get(i))) {
-			   return false;
-		   }
-	   }
+        toRemove.clear();
+        for (Minion targetMinion : waitingPlayer.getMinions()) {
+            if (targetMinion.getTotalHealth() <= 0)
+                toRemove.add(targetMinion);
+        }
+        for (Minion minion : toRemove)
+            waitingPlayer.getMinions().remove(minion);
+    }
 
-	   for (int i = 0; i < p0_hand_.size(); ++i) {
-		   if (!p0_hand_.get(i).equals(((BoardModel)other).p0_hand_.get(i))) {
-			   return false;
-		   }
-	   }
-	   
-	   for (int i = 0; i < p1_hand_.size(); ++i) {
-		   if (!p1_hand_.get(i).equals(((BoardModel)other).p1_hand_.get(i))) {
-			   return false;
-		   }
-	   }
+    public boolean equals(Object other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
 
-	   // More logic here to be discuss below...
-	   return true;
-	}
-	
-	@Override
-	public int hashCode() {
-		int hs = p0_hand_.size();
-		if (hs < 0) hs = 0;
-		int res = hs + p0_minions_.size() * 10 + p1_minions_.size() * 100;
-		res += (p0_mana_ <= 0 ? 0 : (p0_mana_ - 1) * 1000); 
-		res += ((p0_hero_.getHealth() + p1_hero_.getHealth()) % 100) * 10000;
-		int th = 0;
-		if (hs > 0) {
-			Card cc = p0_hand_.get(0);
-			try {
-				Minion mm = (Minion)cc;
-				th += (cc.hasBeenUsed() ? 1 : 0) + mm.getAttack() + mm.getHealth() + cc.getMana();
-			} catch (ClassCastException e) {
-				th += (cc.hasBeenUsed() ? 1 : 0) + cc.getMana();
-			}
-		}
-		if (hs > 1) {
-			Card cc = p0_hand_.get(1);
-			try {
-				Minion mm = (Minion)cc;
-				th += (cc.hasBeenUsed() ? 1 : 0) + mm.getAttack() + mm.getHealth() + cc.getMana();
-			} catch (ClassCastException e) {
-				th += (cc.hasBeenUsed() ? 1 : 0) + cc.getMana();
-			}
-		}
-		res += (th % 10) * 1000000;
-		int mh0 = 0;
-		if (p0_minions_.size() > 0) {
-			mh0 += p0_minions_.get(0).getHealth();
-		}
-		if (p0_minions_.size() > 1) {
-			mh0 += p0_minions_.get(1).getHealth();
-		}
-		res += (mh0 % 100) * 10000000;
-		int mh1 = 0;
-		if (p1_minions_.size() > 0) {
-			mh1 += p1_minions_.get(0).getHealth();
-		}
-		if (p1_minions_.size() > 1) {
-			mh1 += p1_minions_.get(1).getHealth();
-		}
-		res += (mh1 % 20) * 100000000;
-		return res;
-	}
-	
-	/**
-	 * Reset all minions to clear their has_attacked state.
-	 * 
-	 * Call this function at the beginning of each turn
-	 * 
-	 */
-	public void resetMinions() {
-		p0_hero_.hasAttacked(false);
-		p0_hero_.hasBeenUsed(false);
-		p1_hero_.hasAttacked(false);
-		p1_hero_.hasBeenUsed(false);
-		for (Minion minion : p0_minions_) {
-			minion.hasAttacked(false);
-			minion.hasBeenUsed(false);
-		}
-		for (Minion minion : p1_minions_) {
-			minion.hasAttacked(false);
-			minion.hasBeenUsed(false);
-		}
-	}
-	
-	/**
-	 * Reset the has_been_used state of the cards in hand
-	 */
-	public void resetHand() {
-		for(Card card : p0_hand_) {
-			card.hasBeenUsed(false);
-		}
-	}
-	
-	public BoardModel flipPlayers() {
+        if (this.getClass() != other.getClass())
+        {
+            return false;
+        }
 
-		BoardModel newState = (BoardModel)this.deepCopy();
-		MinionList p0_minions = newState.getMinions_p0();
-		MinionList p1_minions = newState.getMinions_p1();
-		int p0_mana = newState.getMana_p0();
-		int p1_mana = newState.getMana_p1();
-		int p0_maxMana = newState.getMaxMana_p0();
-		int p1_maxMana = newState.getMaxMana_p1();
+        if (p0_mana_ != ((BoardModel)other).p0_mana_)
+            return false;
+        if (p1_mana_ != ((BoardModel)other).p1_mana_)
+            return false;
+        if (p0_maxMana_ != ((BoardModel)other).p0_maxMana_)
+            return false;
+        if (p1_maxMana_ != ((BoardModel)other).p1_maxMana_)
+            return false;
 
-        newState.currentPlayer = waitingPlayer;
-        newState.waitingPlayer = currentPlayer;
-		newState.p0_hero_ = p1_hero_;
-		newState.p1_hero_ = p0_hero_;
-		newState.setMinions_p0(p1_minions);
-		newState.setMinions_p1(p0_minions);
-		newState.setMana_p0(p1_mana);
-		newState.setMana_p1(p0_mana);
-		newState.setMaxMana_p0(p1_maxMana);
-		newState.setMaxMana_p1(p0_maxMana);
-		newState.p0_hand_ = p1_hand_;
-		newState.p1_hand_ = p0_hand_;
-		newState.p0_deckPos_ = p1_deckPos_;
-		newState.p1_deckPos_ = p0_deckPos_;
-		newState.p0_fatigueDamage_ = p1_fatigueDamage_;
-		newState.p1_fatigueDamage_ = p0_fatigueDamage_;
-		newState.p0_spellDamage_ = p1_spellDamage_;
-		newState.p1_spellDamage_ = p0_spellDamage_;
-		
-		for (MinionPlayerIDPair minionIdPair : newState.allMinionsFIFOList_) {
-			minionIdPair.playerIndex_ = minionIdPair.playerIndex_ == 0 ? 1 : 0;
-		}
-		return newState;
-	}
-	
-	public Object deepCopy() {
-		BoardModel newBoard = new BoardModel();
+        if (!currentPlayer.getHero().equals(((BoardModel)other).currentPlayer.getHero())) {
+            return false;
+        }
 
-        newBoard.setCurrentPlayer(currentPlayer);
-        newBoard.setWaitingPlayer(waitingPlayer);
-        newBoard.setPlayerModel0(playerModel0);
-        newBoard.setPlayerModel1(playerModel1);
+        if (!waitingPlayer.getHero().equals(((BoardModel)other).waitingPlayer.getHero())) {
+            return false;
+        }
 
-		for (Iterator<Minion> iter = p0_minions_.iterator(); iter.hasNext();) {
-			Minion tc = (Minion)(iter.next()).deepCopy();
-			newBoard.p0_minions_.add(tc);
-		}
-		for (Iterator<Minion> iter = p1_minions_.iterator(); iter.hasNext();) {
-			Minion tc = (Minion)(iter.next()).deepCopy();
-			newBoard.p1_minions_.add(tc);
-		}
-		for (final Card card: p0_hand_) {
-			Card tc = (Card)card.deepCopy();
-			newBoard.placeCard_hand_p0(tc);
-		}
-		for (final Card card: p1_hand_) {
-			Card tc = (Card)card.deepCopy();
-			newBoard.placeCard_hand_p1(tc);
-		}
-		
-		newBoard.setHero_p0((Hero) this.p0_hero_.deepCopy());
-		newBoard.setHero_p1((Hero) this.p1_hero_.deepCopy());
-		
-		newBoard.p0_deckPos_ = this.p0_deckPos_;
-		newBoard.p1_deckPos_ = this.p1_deckPos_;
-		newBoard.p0_fatigueDamage_ = this.p0_fatigueDamage_;
-		newBoard.p1_fatigueDamage_ = this.p1_fatigueDamage_;
-		newBoard.p0_mana_ = this.p0_mana_;
-		newBoard.p1_mana_ = this.p1_mana_;
-		newBoard.p0_maxMana_ = this.p0_maxMana_;
-		newBoard.p1_maxMana_ = this.p1_maxMana_;
-		newBoard.p0_spellDamage_ = this.p0_spellDamage_;
-		newBoard.p1_spellDamage_ = this.p1_spellDamage_;
-		
-		for (MinionPlayerIDPair minionIdPair : allMinionsFIFOList_) {
-			if (minionIdPair.playerIndex_ == 0) {
-				int minionIndex = p0_minions_.indexOf(minionIdPair.minion_);
-				newBoard.allMinionsFIFOList_.add(new MinionPlayerIDPair(newBoard.p0_minions_.get(minionIndex), 0));
-			} else if (minionIdPair.playerIndex_ == 1) {
-				int minionIndex = p1_minions_.indexOf(minionIdPair.minion_);
-				newBoard.allMinionsFIFOList_.add(new MinionPlayerIDPair(newBoard.p1_minions_.get(minionIndex), 1));
-			}
-		}
-		return newBoard;
-	}
-	
-	public JSONObject toJSON() {
-		JSONObject json = new JSONObject();
-		json.put("p0_mana", p0_mana_);
-		json.put("p1_mana", p1_mana_);
-		json.put("p0_maxMana", p0_maxMana_);
-		json.put("p1_maxMana", p0_maxMana_);
-		json.put("p0_deckPos", p0_deckPos_);
-		json.put("p1_deckPos", p1_deckPos_);
+        if (p0_deckPos_ != ((BoardModel)other).p0_deckPos_)
+            return false;
 
-		JSONArray p0_minions = new JSONArray();
-		for (Minion minion : p0_minions_)
-			p0_minions.put(minion.toJSON());
-		json.put("p0_minions", p0_minions);
+        if (p1_deckPos_ != ((BoardModel)other).p1_deckPos_)
+            return false;
 
-		JSONArray p1_minions = new JSONArray();
-		for (Minion minion : p1_minions_)
-			p1_minions.put(minion.toJSON());
-		json.put("p1_minions", p1_minions);
+        if (p0_fatigueDamage_ != ((BoardModel)other).p0_fatigueDamage_)
+            return false;
 
-		JSONArray p0_hand = new JSONArray();
-		for (Card card : p0_hand_)
-			p0_hand.put(card.toJSON());
-		json.put("p0_hand", p0_hand);
-		
-		JSONArray p1_hand = new JSONArray();
-		for (Card card : p1_hand_)
-			p1_hand.put(card.toJSON());
-		json.put("p1_hand", p1_hand);
+        if (p1_fatigueDamage_ != ((BoardModel)other).p1_fatigueDamage_)
+            return false;
 
-		json.put("p0_hero", p0_hero_.toJSON());
-		json.put("p1_hero", p1_hero_.toJSON());
+        if (currentPlayer.getSpellDamage() != ((BoardModel)other).getCurrentPlayer().getSpellDamage())
+            return false;
 
-		json.put("p0_fatigue", p0_fatigueDamage_);
-		json.put("p1_fatigue", p1_fatigueDamage_);
-		json.put("p0_spellDamage", p0_spellDamage_);
-		json.put("p1_spellDamage", p1_spellDamage_);
-		return json;
-	}
-	
-	public String toString() {
+        if (getWaitingPlayer().getSpellDamage() != ((BoardModel)other).getWaitingPlayer().getSpellDamage())
+            return false;
+
+        if (currentPlayer.getMinions().size() != ((BoardModel)other).getCurrentPlayer().getMinions().size())
+            return false;
+        if (waitingPlayer.getMinions().size() != ((BoardModel)other).getWaitingPlayer().getMinions().size())
+            return false;
+        if (currentPlayer.getHand().size() != ((BoardModel)other).getCurrentPlayer().getHand().size())
+            return false;
+
+        for (int i = 0; i < currentPlayer.getMinions().size(); ++i) {
+            if (!currentPlayer.getMinions().get(i).equals(((BoardModel)other).getCurrentPlayer().getMinions().get(i))) {
+                return false;
+            }
+        }
+
+        for (int i = 0; i < waitingPlayer.getMinions().size(); ++i) {
+            if (!waitingPlayer.getMinions().get(i).equals(((BoardModel)other).getWaitingPlayer().getMinions().get(i))) {
+                return false;
+            }
+        }
+
+        for (int i = 0; i < currentPlayer.getHand().size(); ++i) {
+            if (!currentPlayer.getHand().get(i).equals(((BoardModel) other).getCurrentPlayer().getHand().get(i))) {
+                return false;
+            }
+        }
+
+        for (int i = 0; i < waitingPlayer.getHand().size(); ++i) {
+            if (!waitingPlayer.getHand().get(i).equals(((BoardModel)other).waitingPlayer.getHand().get(i))) {
+                return false;
+            }
+        }
+
+        // More logic here to be discuss below...
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hs = currentPlayer.getHand().size();
+        if (hs < 0) hs = 0;
+        int res = hs + getCurrentPlayer().getMinions().size() * 10 + waitingPlayer.getMinions().size() * 100;
+        res += (p0_mana_ <= 0 ? 0 : (p0_mana_ - 1) * 1000);
+        res += ((currentPlayer.getHero().getHealth() + waitingPlayer.getHero().getHealth()) % 100) * 10000;
+        int th = 0;
+        if (hs > 0) {
+            Card cc = currentPlayer.getHand().get(0);
+            try {
+                Minion mm = (Minion)cc;
+                th += (cc.hasBeenUsed() ? 1 : 0) + mm.getAttack() + mm.getHealth() + cc.getMana();
+            } catch (ClassCastException e) {
+                th += (cc.hasBeenUsed() ? 1 : 0) + cc.getMana();
+            }
+        }
+        if (hs > 1) {
+            Card cc = currentPlayer.getHand().get(1);
+            try {
+                Minion mm = (Minion)cc;
+                th += (cc.hasBeenUsed() ? 1 : 0) + mm.getAttack() + mm.getHealth() + cc.getMana();
+            } catch (ClassCastException e) {
+                th += (cc.hasBeenUsed() ? 1 : 0) + cc.getMana();
+            }
+        }
+        res += (th % 10) * 1000000;
+        int mh0 = 0;
+        if (currentPlayer.getMinions().size() > 0) {
+            mh0 += currentPlayer.getMinions().get(0).getHealth();
+        }
+        if (currentPlayer.getMinions().size() > 1) {
+            mh0 += currentPlayer.getMinions().get(1).getHealth();
+        }
+        res += (mh0 % 100) * 10000000;
+        int mh1 = 0;
+        if (waitingPlayer.getMinions().size() > 0) {
+            mh1 += waitingPlayer.getMinions().get(0).getHealth();
+        }
+        if (waitingPlayer.getMinions().size() > 1) {
+            mh1 += waitingPlayer.getMinions().get(1).getHealth();
+        }
+        res += (mh1 % 20) * 100000000;
+        return res;
+    }
+
+    /**
+     * Reset all minions to clear their has_attacked state.
+     *
+     * Call this function at the beginning of each turn
+     *
+     */
+    public void resetMinions() {
+        currentPlayer.getHero().hasAttacked(false);
+        currentPlayer.getHero().hasBeenUsed(false);
+        waitingPlayer.getHero().hasAttacked(false);
+        waitingPlayer.getHero().hasBeenUsed(false);
+        for (Minion minion : currentPlayer.getMinions()) {
+            minion.hasAttacked(false);
+            minion.hasBeenUsed(false);
+        }
+        for (Minion minion : waitingPlayer.getMinions()) {
+            minion.hasAttacked(false);
+            minion.hasBeenUsed(false);
+        }
+    }
+
+    /**
+     * Reset the has_been_used state of the cards in hand
+     */
+    public void resetHand() {
+        for(Card card : currentPlayer.getHand()) {
+            card.hasBeenUsed(false);
+        }
+    }
+
+    public BoardModel flipPlayers() {
+
+        BoardModel newState = (BoardModel)this.deepCopy();
+        int p0_mana = newState.getMana_p0();
+        int p1_mana = newState.getMana_p1();
+        int p0_maxMana = newState.getMaxMana_p0();
+        int p1_maxMana = newState.getMaxMana_p1();
+
+        PlayerModel tmpPlayer = newState.getCurrentPlayer();
+        newState.setCurrentPlayer(newState.getWaitingPlayer());
+        newState.setWaitingPlayer(tmpPlayer);
+        newState.setMana_p0(p1_mana);
+        newState.setMana_p1(p0_mana);
+        newState.setMaxMana_p0(p1_maxMana);
+        newState.setMaxMana_p1(p0_maxMana);
+        newState.p0_deckPos_ = p1_deckPos_;
+        newState.p1_deckPos_ = p0_deckPos_;
+        newState.p0_fatigueDamage_ = p1_fatigueDamage_;
+        newState.p1_fatigueDamage_ = p0_fatigueDamage_;
+
+        return newState;
+    }
+
+    public Object deepCopy() {
+        BoardModel newBoard = new BoardModel();
+
+        newBoard.setCurrentPlayer((PlayerModel) currentPlayer.deepCopy());
+        newBoard.setWaitingPlayer((PlayerModel) waitingPlayer.deepCopy());
+
+        newBoard.p0_deckPos_ = this.p0_deckPos_;
+        newBoard.p1_deckPos_ = this.p1_deckPos_;
+        newBoard.p0_fatigueDamage_ = this.p0_fatigueDamage_;
+        newBoard.p1_fatigueDamage_ = this.p1_fatigueDamage_;
+        newBoard.p0_mana_ = this.p0_mana_;
+        newBoard.p1_mana_ = this.p1_mana_;
+        newBoard.p0_maxMana_ = this.p0_maxMana_;
+        newBoard.p1_maxMana_ = this.p1_maxMana_;
+
+//        for (MinionPlayerIDPair minionIdPair : allMinionsFIFOList_) {
+//            if (minionIdPair.playerIndex_ == 0) {
+//                int minionIndex = p0_minions_.indexOf(minionIdPair.minion_);
+//                newBoard.allMinionsFIFOList_.add(new MinionPlayerIDPair(newBoard.p0_minions_.get(minionIndex), 0));
+//            } else if (minionIdPair.playerIndex_ == 1) {
+//                int minionIndex = p1_minions_.indexOf(minionIdPair.minion_);
+//                newBoard.allMinionsFIFOList_.add(new MinionPlayerIDPair(newBoard.p1_minions_.get(minionIndex), 1));
+//            }
+//        }
+
+        // todo: need to get the minion from the new board and update it to the new player
+        for (MinionPlayerPair minionPlayerPair : allMinionsFIFOList_) {
+
+            PlayerModel oldPlayerModel = minionPlayerPair.getPlayerModel();
+            Minion oldMinion = minionPlayerPair.getMinion();
+            int indexOfOldMinion = oldPlayerModel.getMinions().indexOf(oldMinion);
+
+            PlayerModel newPlayerModel;
+            PlayerModel newWaitingPlayer = newBoard.getWaitingPlayer();
+            PlayerModel newCurrentPlayer = newBoard.getCurrentPlayer();
+            if (oldPlayerModel.equals(currentPlayer)) {
+                newPlayerModel = newCurrentPlayer;
+            } else if (oldPlayerModel.equals(waitingPlayer)) {
+                newPlayerModel = newWaitingPlayer;
+            } else {
+                System.out.println(System.identityHashCode(oldPlayerModel));
+                throw new RuntimeException("WHAHAHAA"); // how is this possible? where does the missing player get in?
+            }
+
+            newBoard.allMinionsFIFOList_.add(new MinionPlayerPair(newPlayerModel.getMinions().get(indexOfOldMinion), newPlayerModel));
+
+        }
+
+        //todo: the problem here is that player references are not updated to new players..
+//        for (MinionPlayerPair minionIdPair : allMinionsFIFOList_) {
+//
+//            if (minionIdPair.playerModel == currentPlayer) {
+//                int minionIndex = currentPlayer.getMinions().indexOf(minionIdPair.minion);
+//                newBoard.allMinionsFIFOList_.add(new MinionPlayerPair(newBoard.getCurrentPlayer().getMinions().get(minionIndex), minionIdPair.playerModel));
+//            } else {
+//                int minionIndex = waitingPlayer.getMinions().indexOf(minionIdPair.minion);
+//                newBoard.allMinionsFIFOList_.add(new MinionPlayerPair(newBoard.getWaitingPlayer().getMinions().get(minionIndex), minionIdPair.playerModel));
+//            }
+//        }
+        return newBoard;
+    }
+
+    public JSONObject toJSON() {
+        JSONObject json = new JSONObject();
+        json.put("p0_mana", p0_mana_);
+        json.put("p1_mana", p1_mana_);
+        json.put("p0_maxMana", p0_maxMana_);
+        json.put("p1_maxMana", p0_maxMana_);
+        json.put("p0_deckPos", p0_deckPos_);
+        json.put("p1_deckPos", p1_deckPos_);
+
+        JSONArray p0_minions = new JSONArray();
+        for (Minion minion : currentPlayer.getMinions())
+            p0_minions.put(minion.toJSON());
+        json.put("p0_minions", p0_minions);
+
+        JSONArray p1_minions = new JSONArray();
+        for (Minion minion : waitingPlayer.getMinions())
+            p1_minions.put(minion.toJSON());
+        json.put("p1_minions", p1_minions);
+
+        JSONArray p0_hand = new JSONArray();
+        for (Card card : currentPlayer.getHand())
+            p0_hand.put(card.toJSON());
+        json.put("p0_hand", p0_hand);
+
+        JSONArray p1_hand = new JSONArray();
+        for (Card card : waitingPlayer.getHand())
+            p1_hand.put(card.toJSON());
+        json.put("p1_hand", p1_hand);
+
+        json.put("p0_hero", currentPlayer.getHero().toJSON());
+        json.put("p1_hero", waitingPlayer.getHero().toJSON());
+
+        json.put("p0_fatigue", p0_fatigueDamage_);
+        json.put("p1_fatigue", p1_fatigueDamage_);
+        json.put("p0_spellDamage", currentPlayer.getSpellDamage());
+        json.put("p1_spellDamage", waitingPlayer.getSpellDamage());
+        return json;
+    }
+
+    public String toString() {
         String boardFormat = MDC.get("board_format");
         if (boardFormat != null && boardFormat.equals("simple")) {
             return simpleString();
@@ -1113,9 +927,9 @@ public class BoardModel implements DeepCopyable {
     private String simpleString() {
         StringBuffer stringBuffer = new StringBuffer();
         stringBuffer.append("[");
-        stringBuffer.append("P0_health:").append(p0_hero_.getHealth()).append(", ");
+        stringBuffer.append("P0_health:").append(currentPlayer.getHero().getHealth()).append(", ");
         stringBuffer.append("P0_mana:").append(p0_mana_).append(", ");
-        stringBuffer.append("P1_health:").append(p1_hero_.getHealth()).append(", ");
+        stringBuffer.append("P1_health:").append(waitingPlayer.getHero().getHealth()).append(", ");
         stringBuffer.append("P1_mana:").append(p1_mana_).append(", ");
         stringBuffer.append("]");
         return stringBuffer.toString();
@@ -1141,19 +955,32 @@ public class BoardModel implements DeepCopyable {
         this.waitingPlayer = waitingPlayer;
     }
 
-    public PlayerModel getPlayerModel0() {
-        return playerModel0;
+    public PlayerModel getOtherPlayer(PlayerModel playerModel){
+        PlayerModel otherPlayer;
+        if (playerModel == currentPlayer){
+            otherPlayer = waitingPlayer;
+        }else{
+            otherPlayer = currentPlayer;
+        }
+        return otherPlayer;
     }
 
-    public void setPlayerModel0(PlayerModel playerModel0) {
-        this.playerModel0 = playerModel0;
+    // todo: remove asap, simply to aid in refactoring
+    public int getIndexOfPlayer(PlayerModel playerModel) {
+        if (playerModel == currentPlayer){
+            return 0;
+        }else{
+            return 1;
+        }
     }
 
-    public PlayerModel getPlayerModel1() {
-        return playerModel1;
+    // todo: remove asap, simply to aid in refactoring
+    public PlayerModel getPlayerByIndex(int index) {
+        if (index == 0){
+            return currentPlayer;
+        }else{
+            return waitingPlayer;
+        }
     }
 
-    public void setPlayerModel1(PlayerModel playerModel1) {
-        this.playerModel1 = playerModel1;
-    }
 }

--- a/src/main/java/com/hearthsim/model/PlayerModel.java
+++ b/src/main/java/com/hearthsim/model/PlayerModel.java
@@ -3,34 +3,50 @@ package com.hearthsim.model;
 import com.hearthsim.card.Card;
 import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
+import com.hearthsim.card.minion.Minion;
+import com.hearthsim.exception.HSInvalidPlayerIndexException;
+import com.hearthsim.util.DeepCopyable;
+import com.hearthsim.util.IdentityLinkedList;
+import com.hearthsim.util.MinionList;
 import org.json.JSONObject;
 
-public class PlayerModel {
+import java.util.Iterator;
 
-	String name;
-	public final Hero hero;
-	final Deck deck;
-	int mana;
+public class PlayerModel implements DeepCopyable {
 
-	public PlayerModel(String name, Hero hero, Deck deck) {
-		this.name = name;
-		this.hero = hero;
-		this.deck = deck;
-	}
-	
-	public Card drawFromDeck(int index) {
-		Card card = deck.drawCard(index);
-		if (card == null) {
-			return null;
-		}
-		card.isInHand(true);
-		return card;
-	}
+    private String name;
+    private Hero hero;
+    private Deck deck;
+    private int mana;
+    private MinionList minions;
+    private byte spellDamage;
+    private IdentityLinkedList<Card> hand;
+    byte overload;
 
+    public PlayerModel(String name, Hero hero, Deck deck) {
+        this.name = name;
+        this.hero = hero;
+        this.deck = deck;
+        this.minions = new MinionList();
+        this.hand = new IdentityLinkedList<>();
+    }
 
-	public Deck getDeck() {
-		return deck;
-	}
+    public Card drawFromDeck(int index) {
+        Card card = deck.drawCard(index);
+        if (card == null) {
+            return null;
+        }
+        card.isInHand(true);
+        return card;
+    }
+
+    public int getNumMinions() {
+        return minions.size();
+    }
+
+    public Deck getDeck() {
+        return deck;
+    }
 
     public String getName() {
         return name;
@@ -56,7 +72,83 @@ public class PlayerModel {
         this.mana = mana;
     }
 
+    public MinionList getMinions() {
+        return minions;
+    }
+
+    public void setMinions(MinionList minions) {
+        this.minions = minions;
+    }
+
+    public void setHero(Hero hero) {
+        this.hero = hero;
+    }
+
+    public void setDeck(Deck deck) {
+        this.deck = deck;
+    }
+
+    public byte getSpellDamage() {
+        return spellDamage;
+    }
+
+    public void setSpellDamage(byte spellDamage) {
+        this.spellDamage = spellDamage;
+    }
+
+    public IdentityLinkedList<Card> getHand() {
+        return hand;
+    }
+
+    public void setHand(IdentityLinkedList<Card> hand) {
+        this.hand = hand;
+    }
+
+    public byte getOverload() {
+        return overload;
+    }
+
+    public void setOverload(byte overload) {
+        this.overload = overload;
+    }
+
     public String toString() {
         return new JSONObject(this).toString();
-	}
+    }
+
+    @Override
+    public Object deepCopy() {
+        PlayerModel copiedPlayerModel = new PlayerModel(
+                this.name,
+                (Hero) this.hero.deepCopy(),
+                this.deck //todo should be a deep copy, we're just using the index in boardmodel right now to compensate..
+        );
+
+        copiedPlayerModel.setMana(mana);
+        copiedPlayerModel.setOverload(overload);
+
+        for (Minion minion : minions) {
+            copiedPlayerModel.getMinions().add((Minion) (minion).deepCopy());
+        }
+
+        copiedPlayerModel.setSpellDamage(spellDamage);
+
+        for (final Card card: hand) {
+            Card tc = (Card)card.deepCopy();
+            copiedPlayerModel.placeCardHand(tc);
+        }
+
+        return copiedPlayerModel;
+    }
+
+    public void placeCardHand(Card card) {
+        card.isInHand(true);
+        hand.add(card);
+    }
+
+    public void placeCardHand(int cardIndex) {
+        Card card = drawFromDeck(cardIndex);
+        card.isInHand(true);
+        hand.add(card);
+    }
 }

--- a/src/main/java/com/hearthsim/player/playercontroller/ArtificialPlayer.java
+++ b/src/main/java/com/hearthsim/player/playercontroller/ArtificialPlayer.java
@@ -192,9 +192,9 @@ public class ArtificialPlayer {
 		IdentityLinkedList<Minion> myBoardCards;
 		IdentityLinkedList<Minion> opBoardCards;
 		IdentityLinkedList<Card> myHandCards;
-		myBoardCards = board.getMinions_p0();
-		opBoardCards = board.getMinions_p1();
-		myHandCards = board.getCards_hand_p0();
+		myBoardCards = board.getCurrentPlayer().getMinions();
+		opBoardCards = board.getWaitingPlayer().getMinions();
+		myHandCards = board.getCurrentPlayerHand();
 		
 		//my board score
 		double myScore = 0.0;
@@ -217,8 +217,8 @@ public class ArtificialPlayer {
 		
 		//weapons
 		double weaponScore = 0.0;
-		weaponScore += board.getHero_p0().getAttack() * board.getHero_p0().getWeaponCharge() * myWeaponWeight;
-		weaponScore -= board.getHero_p1().getAttack() * board.getHero_p1().getWeaponCharge() * enemyWeaponWeight;
+		weaponScore += board.getCurrentPlayerHero().getAttack() * board.getCurrentPlayerHero().getWeaponCharge() * myWeaponWeight;
+		weaponScore -= board.getWaitingPlayerHero().getAttack() * board.getWaitingPlayerHero().getWeaponCharge() * enemyWeaponWeight;
 		
 		//my cards.  The more cards that I have, the better
 		double handScore = 0.0;
@@ -228,13 +228,13 @@ public class ArtificialPlayer {
 		
 		//the more we beat on the opponent hero, the better
 		double heroScore = 0;
-		heroScore += heroHealthScore_p0(board.getHero_p0().getHealth(), board.getHero_p0().getArmor());
-		heroScore += heroHealthScore_p1(board.getHero_p1().getHealth(), board.getHero_p1().getArmor());
+		heroScore += heroHealthScore_p0(board.getCurrentPlayerHero().getHealth(), board.getCurrentPlayerHero().getArmor());
+		heroScore += heroHealthScore_p1(board.getWaitingPlayerHero().getHealth(), board.getWaitingPlayerHero().getArmor());
 		
 		//the more minions you have, the better.  The less minions the enemy has, the better
 		double minionScore = 0.0;
-		minionScore += myNumMinionsWeight * (board.getNumMinions_p0());
-		minionScore -= enemyNumMinionsWeight * (board.getNumMinions_p1());
+		minionScore += myNumMinionsWeight * (board.getCurrentPlayer().getNumMinions());
+		minionScore -= enemyNumMinionsWeight * (board.getWaitingPlayer().getNumMinions());
 		
 		double score = myScore - opScore + handScore + heroScore + minionScore + weaponScore;
 		

--- a/src/main/java/com/hearthsim/results/GameDetailedRecord.java
+++ b/src/main/java/com/hearthsim/results/GameDetailedRecord.java
@@ -2,6 +2,7 @@ package com.hearthsim.results;
 
 import com.hearthsim.exception.HSInvalidPlayerIndexException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
@@ -18,8 +19,9 @@ public class GameDetailedRecord implements GameRecord {
 	}
 	
 	@Override
-	public void put(int turn, int activePlayerIndex, BoardModel board) {
-		boards_.get(activePlayerIndex).put(turn, board);
+	public void put(int turn, PlayerModel activePlayerModel, BoardModel board) {
+        int index = board.getIndexOfPlayer(activePlayerModel);
+        boards_.get(index).put(turn, board);
 	}
 	
 	@Override
@@ -28,18 +30,20 @@ public class GameDetailedRecord implements GameRecord {
 	}
 
 	@Override
-	public int getNumMinions(int playerIndex, int turn, int activePlayerIndex) {
-		try {
-			return boards_.get(activePlayerIndex).get(turn).getNumMinions((playerIndex + activePlayerIndex) % 2);
-		} catch (HSInvalidPlayerIndexException e) {
-			return 0;
-		}
-	}
+    public int getNumMinions(int playerIndex, int turn, int activePlayerIndex) {
+        BoardModel boardModel = boards_.get(activePlayerIndex).get(turn);
+        PlayerModel playerByIndex = boardModel.getPlayerByIndex(playerIndex);
+        PlayerModel otherPlayer = boardModel.getOtherPlayer(playerByIndex);
+        return otherPlayer.getNumMinions();
+    }
 
 	@Override
 	public int getNumCardsInHand(int playerIndex, int turn, int activePlayerIndex) {
 		try {
-			return boards_.get(activePlayerIndex).get(turn).getNumCards_hand((playerIndex + activePlayerIndex) % 2);
+            BoardModel boardModel = boards_.get(activePlayerIndex).get(turn);
+            PlayerModel playerByIndex = boardModel.getPlayerByIndex(playerIndex);
+            PlayerModel otherPlayer = boardModel.getOtherPlayer(playerByIndex);
+            return boardModel.getNumCards_hand(otherPlayer);
 		} catch (HSInvalidPlayerIndexException e) {
 			return 0;
 		}
@@ -48,7 +52,11 @@ public class GameDetailedRecord implements GameRecord {
 	@Override
 	public int getHeroHealth(int playerIndex, int turn, int activePlayerIndex) {
 		try {
-			return boards_.get(activePlayerIndex).get(turn).getHero((playerIndex + activePlayerIndex) % 2).getHealth();
+
+            BoardModel boardModel = boards_.get(activePlayerIndex).get(turn);
+            PlayerModel playerByIndex = boardModel.getPlayerByIndex(playerIndex);
+            PlayerModel otherPlayer = boardModel.getOtherPlayer(playerByIndex);
+            return boardModel.getHero(otherPlayer).getHealth();
 		} catch (HSInvalidPlayerIndexException e) {
 			return 0;
 		}
@@ -57,7 +65,10 @@ public class GameDetailedRecord implements GameRecord {
 	@Override
 	public int getHeroArmor(int playerIndex, int turn, int activePlayerIndex) {
 		try {
-			return boards_.get(activePlayerIndex).get(turn).getHero((playerIndex + activePlayerIndex) % 2).getArmor();
+            BoardModel boardModel = boards_.get(activePlayerIndex).get(turn);
+            PlayerModel playerByIndex = boardModel.getPlayerByIndex(playerIndex);
+            PlayerModel otherPlayer = boardModel.getOtherPlayer(playerByIndex);
+            return boardModel.getHero(otherPlayer).getArmor();
 		} catch (HSInvalidPlayerIndexException e) {
 			return 0;
 		}

--- a/src/main/java/com/hearthsim/results/GameRecord.java
+++ b/src/main/java/com/hearthsim/results/GameRecord.java
@@ -1,18 +1,18 @@
 package com.hearthsim.results;
 
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import org.json.JSONObject;
 
 public interface GameRecord {
 	
 	/**
 	 * Put a record
-	 * 
-	 * @param turn The turn number
-	 * @param activePlayerIndex Index of the player that just played a turn
-	 * @param board
-	 */
-	public void put(int turn, int activePlayerIndex, BoardModel board);
+	 *  @param turn The turn number
+	 * @param activePlayerModel Index of the player that just played a turn
+     * @param board
+     */
+	public void put(int turn, PlayerModel activePlayerModel, BoardModel board);
 	
 	/**
 	 * Return the number of turns recorded for each player

--- a/src/main/java/com/hearthsim/results/GameSimpleRecord.java
+++ b/src/main/java/com/hearthsim/results/GameSimpleRecord.java
@@ -1,7 +1,9 @@
 package com.hearthsim.results;
 
+import com.hearthsim.card.minion.Hero;
 import com.hearthsim.exception.HSException;
 import com.hearthsim.model.BoardModel;
+import com.hearthsim.model.PlayerModel;
 import org.json.JSONObject;
 
 public class GameSimpleRecord implements GameRecord {
@@ -25,26 +27,31 @@ public class GameSimpleRecord implements GameRecord {
 	}
 	
 	@Override
-	public void put(int turn, int activePlayerIndex, BoardModel board) {
-		try {
-			int inactivePlayerIndex = (activePlayerIndex + 1) % 2;
-			
-			numMinions_[activePlayerIndex][turn][activePlayerIndex] = (byte)board.getNumMinions(0);
-			numMinions_[activePlayerIndex][turn][inactivePlayerIndex] = (byte)board.getNumMinions(1);
+	public void put(int turn, PlayerModel activePlayerModel, BoardModel board) {
+        int activePlayerIndex;
+        int inactivePlayerIndex;
+        if (board.getCurrentPlayer() == activePlayerModel) {
+            activePlayerIndex = 0;
+            inactivePlayerIndex = 1;
+        } else {
+            activePlayerIndex = 1;
+            inactivePlayerIndex = 0;
+        }
 
-			numCards_[activePlayerIndex][turn][activePlayerIndex] = (byte)board.getNumCards_hand(0);
-			numCards_[activePlayerIndex][turn][inactivePlayerIndex] = (byte)board.getNumCards_hand(1);
+        numMinions_[activePlayerIndex][turn][activePlayerIndex] = (byte)board.getCurrentPlayer().getNumMinions();
+        numMinions_[activePlayerIndex][turn][inactivePlayerIndex] = (byte)board.getWaitingPlayer().getNumMinions();
 
-			heroHealth_[activePlayerIndex][turn][activePlayerIndex] = board.getHero(0).getHealth();
-			heroHealth_[activePlayerIndex][turn][inactivePlayerIndex] = board.getHero(1).getHealth();
+        numCards_[activePlayerIndex][turn][activePlayerIndex] = (byte)board.getNumCardsHandCurrentPlayer();
+        numCards_[activePlayerIndex][turn][inactivePlayerIndex] = (byte)board.getNumCardsHandWaitingPlayer();
 
-			heroArmor_[activePlayerIndex][turn][activePlayerIndex] = board.getHero(0).getArmor();
-			heroArmor_[activePlayerIndex][turn][inactivePlayerIndex] = board.getHero(1).getArmor();
+        Hero currentPlayerHero = board.getCurrentPlayerHero();
+        heroHealth_[activePlayerIndex][turn][activePlayerIndex] = currentPlayerHero.getHealth();
+        Hero waitingPlayerHero = board.getWaitingPlayerHero();
+        heroHealth_[activePlayerIndex][turn][inactivePlayerIndex] = waitingPlayerHero.getHealth();
 
-		} catch (HSException e) {
-			e.printStackTrace();
-		}
-	}
+        heroArmor_[activePlayerIndex][turn][activePlayerIndex] = currentPlayerHero.getArmor();
+        heroArmor_[activePlayerIndex][turn][inactivePlayerIndex] = waitingPlayerHero.getArmor();
+    }
 
 	@Override
 	public int getRecordLength(int playerIndex) {

--- a/src/main/java/com/hearthsim/util/HearthAction.java
+++ b/src/main/java/com/hearthsim/util/HearthAction.java
@@ -5,6 +5,7 @@ import com.hearthsim.card.Deck;
 import com.hearthsim.card.minion.Hero;
 import com.hearthsim.card.minion.Minion;
 import com.hearthsim.exception.HSException;
+import com.hearthsim.model.PlayerModel;
 import com.hearthsim.util.tree.HearthTreeNode;
 
 
@@ -21,18 +22,18 @@ public class HearthAction {
 		
 	public final Verb verb_;
 	
-	public final int actionPerformerPlayerIndex_;
+	public final PlayerModel actionPerformerPlayerModel;
 	public final int cardOrCharacterIndex_;
 	
-	public final int targetPlayerIndex_;
+	public final PlayerModel targetPlayerModel;
 	public final int targetCharacterIndex_;
 	
-	public HearthAction(Verb verb, int actionPerformerPlayerIndex, int cardOrCharacterIndex, int targetPlayerIndex, int targetCharacterIndex) {
+	public HearthAction(Verb verb, PlayerModel actionPerformerPlayerModel, int cardOrCharacterIndex, PlayerModel targetPlayerModel, int targetCharacterIndex) {
 		verb_ = verb;
-		actionPerformerPlayerIndex_ = actionPerformerPlayerIndex;
+		this.actionPerformerPlayerModel = actionPerformerPlayerModel;
 		cardOrCharacterIndex_ = cardOrCharacterIndex;
 
-		targetPlayerIndex_ = targetPlayerIndex;
+		this.targetPlayerModel = targetPlayerModel;
 		targetCharacterIndex_ = targetCharacterIndex;
 	}
 
@@ -40,21 +41,21 @@ public class HearthAction {
 		HearthTreeNode toRet = boardState;
 		switch(verb_) {
 			case USE_CARD: {
-				Card card = boardState.data_.getCard_hand(actionPerformerPlayerIndex_, cardOrCharacterIndex_);
-				Minion target = boardState.data_.getCharacter(targetPlayerIndex_, targetCharacterIndex_);
-				toRet = card.useOn(targetPlayerIndex_, target, toRet, deckPlayer0, deckPlayer1, true);
+				Card card = boardState.data_.getCard_hand(actionPerformerPlayerModel, cardOrCharacterIndex_);
+				Minion target = boardState.data_.getCharacter(targetPlayerModel, targetCharacterIndex_);
+				toRet = card.useOn(targetPlayerModel, target, toRet, deckPlayer0, deckPlayer1, true);
 			}
 			break;
 			case HERO_ABILITY: {
-				Hero hero = boardState.data_.getHero(actionPerformerPlayerIndex_);
-				Minion target = boardState.data_.getCharacter(targetPlayerIndex_, targetCharacterIndex_);
-				toRet = hero.useHeroAbility(targetPlayerIndex_, target, toRet, deckPlayer0, deckPlayer1, true);
+				Hero hero = boardState.data_.getHero(actionPerformerPlayerModel);
+				Minion target = boardState.data_.getCharacter(targetPlayerModel, targetCharacterIndex_);
+				toRet = hero.useHeroAbility(targetPlayerModel, target, toRet, deckPlayer0, deckPlayer1, true);
 			}
 			break;
 			case ATTACK: {
-				Minion attacker = boardState.data_.getCharacter(actionPerformerPlayerIndex_, cardOrCharacterIndex_);
-				Minion target = boardState.data_.getCharacter(targetPlayerIndex_, targetCharacterIndex_);
-				toRet = attacker.attack(targetPlayerIndex_, target, toRet, deckPlayer0, deckPlayer1);
+				Minion attacker = boardState.data_.getCharacter(actionPerformerPlayerModel, cardOrCharacterIndex_);
+				Minion target = boardState.data_.getCharacter(targetPlayerModel, targetCharacterIndex_);
+				toRet = attacker.attack(targetPlayerModel, target, toRet, deckPlayer0, deckPlayer1);
 			}
 			break;
 		}

--- a/src/main/java/com/hearthsim/util/tree/CardDrawNode.java
+++ b/src/main/java/com/hearthsim/util/tree/CardDrawNode.java
@@ -55,9 +55,9 @@ public class CardDrawNode extends StopNode {
 		if (card == null) {
 			byte fatigueDamage = data_.getFatigueDamage_p0();
 			data_.setFatigueDamage_p0((byte)(fatigueDamage + 1));
-			data_.getHero_p0().setHealth((byte)(data_.getHero_p0().getHealth() - fatigueDamage));
+			data_.getCurrentPlayerHero().setHealth((byte)(data_.getCurrentPlayerHero().getHealth() - fatigueDamage));
 		} else {
-			data_.placeCard_hand_p0(card);
+			data_.placeCardHandCurrentPlayer(card);
 			data_.setDeckPos_p0(data_.getDeckPos_p0() + 1);
 		}
 	}
@@ -85,8 +85,8 @@ public class CardDrawNode extends StopNode {
 		averageCardScore = numCardsRemaining <= 0 ? 0.0 : averageCardScore / numCardsRemaining;
 		
 		double toRet = averageCardScore * numCardsToActuallyDraw;
-		int heroHealth = data_.getHero_p0().getHealth();
-		int heroArmor = data_.getHero_p0().getArmor();
+		int heroHealth = data_.getCurrentPlayerHero().getHealth();
+		int heroArmor = data_.getCurrentPlayerHero().getArmor();
 		int armorLeft = heroArmor > totalFatigueDamage ? heroArmor - totalFatigueDamage : 0;
 		int healthLeft = armorLeft > 0 ? heroHealth : heroHealth - (totalFatigueDamage - heroArmor);
 		toRet += ai.heroHealthScore_p0(healthLeft, armorLeft) - ai.heroHealthScore_p0(heroHealth, heroArmor);

--- a/src/test/java/com/hearthsim/test/TestCharge.java
+++ b/src/test/java/com/hearthsim/test/TestCharge.java
@@ -36,13 +36,13 @@ public class TestCharge {
 		scoreFunc = new DummyStateFunc();
 
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
-		board.placeMinion(1, minion1_0);
+		board.placeMinion(board.getWaitingPlayer(), minion1_0);
 				
 	}
 	@Test
 	public void test0() throws HSException {
 		Minion minion = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, false, false, false, true, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
-		board.placeMinion(0, minion);
+		board.placeMinion(board.getCurrentPlayer(), minion);
 		
 		BoardStateFactoryBase factory = new BoardStateFactoryBase(null, null, 2000000000);
 		HearthTreeNode tree = new HearthTreeNode(board);
@@ -60,7 +60,7 @@ public class TestCharge {
 	@Test
 	public void test1() {
 		Minion minion = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, false, false, false, true, false, false, false, false, false, false, false, false, false, false, null, null, true, false);
-		board.placeCard_hand_p0(minion);
+		board.placeCardHandCurrentPlayer(minion);
 		board.setMana_p0(1);
 		
 		BoardStateFactoryBase factory = new BoardStateFactoryBase(null, null);

--- a/src/test/java/com/hearthsim/test/TestEvents.java
+++ b/src/test/java/com/hearthsim/test/TestEvents.java
@@ -23,11 +23,11 @@ public class TestEvents {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, health1, attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 				
 	}
 

--- a/src/test/java/com/hearthsim/test/TestJson.java
+++ b/src/test/java/com/hearthsim/test/TestJson.java
@@ -29,11 +29,11 @@ public class TestJson {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -43,7 +43,7 @@ public class TestJson {
 		deck = new Deck(cards);
 
 		Minion fb = new GnomishInventor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)7);

--- a/src/test/java/com/hearthsim/test/TestTaunt.java
+++ b/src/test/java/com/hearthsim/test/TestTaunt.java
@@ -38,14 +38,14 @@ public class TestTaunt {
 
 		Minion minion0_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		
-		board.placeMinion(0, minion0_0);
+		board.placeMinion(board.getCurrentPlayer(), minion0_0);
 				
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		Minion minion = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, true, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
-		board.placeMinion(1, minion);
+		board.placeMinion(board.getWaitingPlayer(), minion);
 		
 		BoardStateFactoryBase factory = new BoardStateFactoryBase(null, null);
 		HearthTreeNode tree = new HearthTreeNode(board);
@@ -66,8 +66,8 @@ public class TestTaunt {
 	public void test1() throws HSException {
 		Minion minion1 = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, true, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
 		Minion minion2 = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, false, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
-		board.placeMinion(1, minion1);
-		board.placeMinion(1, minion2);
+		board.placeMinion(board.getWaitingPlayer(), minion1);
+		board.placeMinion(board.getWaitingPlayer(), minion2);
 		
 		BoardStateFactoryBase factory = new BoardStateFactoryBase(null, null);
 		HearthTreeNode tree = new HearthTreeNode(board);
@@ -89,9 +89,9 @@ public class TestTaunt {
 		Minion minion1 = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, true, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
 		Minion minion2 = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, false, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
 		Minion minion3 = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, true, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
-		board.placeMinion(1, minion1);
-		board.placeMinion(1, minion2);
-		board.placeMinion(1, minion3);
+		board.placeMinion(board.getWaitingPlayer(), minion1);
+		board.placeMinion(board.getWaitingPlayer(), minion2);
+		board.placeMinion(board.getWaitingPlayer(), minion3);
 		
 		BoardStateFactoryBase factory = new BoardStateFactoryBase(null, null);
 		HearthTreeNode tree = new HearthTreeNode(board);
@@ -114,9 +114,9 @@ public class TestTaunt {
 		HolySmite hs = new HolySmite();
 		Minion minion1 = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, true, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
 
-		board.removeMinion(0, 0);
-		board.placeCard_hand_p0(hs);
-		board.placeMinion(1, minion1);
+		board.removeMinion(board.getCurrentPlayer(), 0);
+		board.placeCardHandCurrentPlayer(hs);
+		board.placeMinion(board.getWaitingPlayer(), minion1);
 		
 		BoardStateFactoryBase factory = new BoardStateFactoryBase(null, null, 2000000000);
 		HearthTreeNode tree = new HearthTreeNode(board);
@@ -138,9 +138,9 @@ public class TestTaunt {
 		HolySmite hs = new HolySmite();
 		Minion minion1 = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, true, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
 
-		board.removeMinion(0, 0);
-		board.placeCard_hand_p0(hs);
-		board.placeMinion(1, minion1);
+		board.removeMinion(board.getCurrentPlayer(), 0);
+		board.placeCardHandCurrentPlayer(hs);
+		board.placeMinion(board.getWaitingPlayer(), minion1);
 		board.setMana_p0(1);
 		
 		BoardStateFactoryBase factory = new BoardStateFactoryBase(null, null);
@@ -165,9 +165,9 @@ public class TestTaunt {
 		HolySmite hs = new HolySmite();
 		Minion minion1 = new Minion("" + 0, mana, attack0, health1, attack0, (byte)0, (byte)0, health1, health1, (byte)0, (byte)0, true, false, false, false, false, false, false, false, false, false, false, false, false, false, null, null, false, false);
 
-		board.removeMinion(0, 0);
-		board.placeCard_hand_p0(hs);
-		board.placeMinion(1, minion1);
+		board.removeMinion(board.getCurrentPlayer(), 0);
+		board.placeCardHandCurrentPlayer(hs);
+		board.placeMinion(board.getWaitingPlayer(), minion1);
 		board.setMana_p0(2);
 		
 		BoardStateFactoryBase factory = new BoardStateFactoryBase(null, null, 2000000000);

--- a/src/test/java/com/hearthsim/test/card/TestAncestralHealing.java
+++ b/src/test/java/com/hearthsim/test/card/TestAncestralHealing.java
@@ -27,9 +27,9 @@ public class TestAncestralHealing {
 		Minion minion1 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 
 		AncestralHealing fb = new AncestralHealing();
-		board.data_.placeCard_hand_p0(fb);
-		board.data_.placeMinion(0, minion0);
-		board.data_.placeMinion(1, minion1);
+		board.data_.placeCardHandCurrentPlayer(fb);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1);
 		board.data_.setMana_p0(2);
 	}
 	
@@ -37,12 +37,12 @@ public class TestAncestralHealing {
 	@Test
 	public void test0() throws HSException {
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		
 		try {
-			Minion target = board.data_.getCharacter(0, 0);
-			res = theCard.useOn(0, target, board, null, null);
+			Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+			res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 			assertTrue(res == null);
 		} catch (HSInvalidPlayerIndexException e) {
 			e.printStackTrace();
@@ -50,8 +50,8 @@ public class TestAncestralHealing {
 		}
 		
 		try {
-			Minion target = board.data_.getCharacter(1, 0);
-			res = theCard.useOn(1, target, board, null, null);
+			Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+			res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 			assertTrue(res == null);
 		} catch (HSInvalidPlayerIndexException e) {
 			e.printStackTrace();
@@ -63,19 +63,19 @@ public class TestAncestralHealing {
 	@Test
 	public void test1() throws HSException {
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		
 		try {
-			Minion target = board.data_.getCharacter(0, 1);			
-			res = theCard.useOn(0, target, board, null, null);
+			Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+			res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 			assertFalse(res == null);
 			assertTrue(res.data_.getMana_p0() == 2);
 			assertTrue(res.data_.getNumCards_hand() == 0);
-			assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-			assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-			assertTrue(res.data_.getMinion_p0(0).getMaxHealth() == health0);
-			assertTrue(res.data_.getMinion_p0(0).getTaunt());
+			assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+			assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+			assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getMaxHealth() == health0);
+			assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTaunt());
 		} catch (HSInvalidPlayerIndexException e) {
 			e.printStackTrace();
 			assertTrue(false);
@@ -85,19 +85,19 @@ public class TestAncestralHealing {
 	@Test
 	public void test2() throws HSException {
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		
 		try {
-			Minion target = board.data_.getCharacter(0, 1);			
-			res = theCard.useOn(0, target, board, null, null);
+			Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+			res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 			assertFalse(res == null);
 			assertTrue(res.data_.getMana_p0() == 2);
 			assertTrue(res.data_.getNumCards_hand() == 0);
-			assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-			assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-			assertTrue(res.data_.getMinion_p0(0).getMaxHealth() == health0);
-			assertTrue(res.data_.getMinion_p0(0).getTaunt());
+			assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+			assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+			assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getMaxHealth() == health0);
+			assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTaunt());
 		} catch (HSInvalidPlayerIndexException e) {
 			e.printStackTrace();
 			assertTrue(false);
@@ -107,19 +107,19 @@ public class TestAncestralHealing {
 	@Test
 	public void test3() throws HSException {
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		
 		try {
-			Minion target = board.data_.getCharacter(1, 1);
-			res = theCard.useOn(1, target, board, null, null);
+			Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+			res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 			assertFalse(res == null);
 			assertTrue(res.data_.getMana_p0() == 2);
 			assertTrue(res.data_.getNumCards_hand() == 0);
-			assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-			assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-			assertTrue(res.data_.getMinion_p1(0).getMaxHealth() == health0);
-			assertTrue(res.data_.getMinion_p1(0).getTaunt());
+			assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+			assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+			assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getMaxHealth() == health0);
+			assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTaunt());
 		} catch (HSInvalidPlayerIndexException e) {
 			e.printStackTrace();
 			assertTrue(false);
@@ -129,19 +129,19 @@ public class TestAncestralHealing {
 	@Test
 	public void test4() throws HSException {
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		
 		try {
-			Minion target = board.data_.getCharacter(1, 1);
-			res = theCard.useOn(1, target, board, null, null);
+			Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+			res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 			assertFalse(res == null);
 			assertTrue(res.data_.getMana_p0() == 2);
 			assertTrue(res.data_.getNumCards_hand() == 0);
-			assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-			assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-			assertTrue(res.data_.getMinion_p1(0).getMaxHealth() == health0);
-			assertTrue(res.data_.getMinion_p1(0).getTaunt());
+			assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+			assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+			assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getMaxHealth() == health0);
+			assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTaunt());
 		} catch (HSInvalidPlayerIndexException e) {
 			e.printStackTrace();
 			assertTrue(false);

--- a/src/test/java/com/hearthsim/test/card/TestAnimalCompanion.java
+++ b/src/test/java/com/hearthsim/test/card/TestAnimalCompanion.java
@@ -33,11 +33,11 @@ public class TestAnimalCompanion {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,7 +47,7 @@ public class TestAnimalCompanion {
 		deck = new Deck(cards);
 
 		AnimalCompanion fb = new AnimalCompanion();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)4);
 		board.data_.setMana_p1((byte)4);
@@ -61,125 +61,125 @@ public class TestAnimalCompanion {
 	public void testLeokk0() throws HSException {
 		
 		Card leokk = new Leokk();
-		board.data_.placeCard_hand_p0(leokk);
+		board.data_.placeCardHandCurrentPlayer(leokk);
 		
-		Card theCard = board.data_.getCard_hand_p0(1);
-		Minion target = board.data_.getCharacter(1, 0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Card theCard = board.data_.getCurrentPlayerCardHand(1);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 2);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void testLeokk1() throws HSException {
 		
 		Card leokk = new Leokk();
-		board.data_.placeCard_hand_p0(leokk);
+		board.data_.placeCardHandCurrentPlayer(leokk);
 		
-		Card theCard = board.data_.getCard_hand_p0(1);
-		Minion target = board.data_.getCharacter(0, 2);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Card theCard = board.data_.getCurrentPlayerCardHand(1);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		//Use Leokk.  The other minions should now be buffed with +1 attack
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0 + 1);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0 + 1);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0 + 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0 + 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 
 		
 		//Now, attack and kill Leokk.  All minions should go back to their original attack
-		Minion minion = board.data_.getMinion_p0(2);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(2);
 		minion.hasAttacked(false);
-		Minion target2 = board.data_.getCharacter(1, 1);
-		ret = minion.attack(1, target2, board, deck, null);
+		Minion target2 = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = minion.attack(board.data_.getWaitingPlayer(), target2, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0 - 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0 - 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
-		Minion target = board.data_.getCharacter(1, 0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
-		Minion target = board.data_.getCharacter(0, 0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(0, board.data_.getNumCards_hand());
 		assertEquals(1, board.data_.getMana_p0());
-		assertEquals(3, board.data_.getNumMinions_p0());
-		assertEquals(2, board.data_.getNumMinions_p1());
-		assertEquals(30, board.data_.getHero_p0().getHealth());
-		assertEquals(30, board.data_.getHero_p1().getHealth());
-		assertEquals(health0, board.data_.getMinion_p0(0).getHealth());
-		assertEquals(health1 - 1, board.data_.getMinion_p0(1).getHealth());
-		assertEquals(health0, board.data_.getMinion_p1(0).getHealth());
-		assertEquals(health1  - 1, board.data_.getMinion_p1(1).getHealth());
+		assertEquals(3, board.data_.getCurrentPlayer().getNumMinions());
+		assertEquals(2, board.data_.getWaitingPlayer().getNumMinions());
+		assertEquals(30, board.data_.getCurrentPlayerHero().getHealth());
+		assertEquals(30, board.data_.getWaitingPlayerHero().getHealth());
+		assertEquals(health0, board.data_.getCurrentPlayer().getMinions().get(0).getHealth());
+		assertEquals(health1 - 1, board.data_.getCurrentPlayer().getMinions().get(1).getHealth());
+		assertEquals(health0, board.data_.getWaitingPlayer().getMinions().get(0).getHealth());
+		assertEquals(health1  - 1, board.data_.getWaitingPlayer().getMinions().get(1).getHealth());
 
-		if (board.data_.getMinion_p0(2) instanceof Leokk) {
-			assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0 + 1);
-			assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0 + 1);
+		if (board.data_.getCurrentPlayer().getMinions().get(2) instanceof Leokk) {
+			assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0 + 1);
+			assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0 + 1);
 		} else {
-			assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-			assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
+			assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+			assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
 		}
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestArcaneExplosion.java
+++ b/src/test/java/com/hearthsim/test/card/TestArcaneExplosion.java
@@ -29,11 +29,11 @@ public class TestArcaneExplosion {
 		Minion minion3 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 
 		ArcaneExplosion fb = new ArcaneExplosion();
-		board.data_.placeCard_hand_p0(fb);
-		board.data_.placeMinion(0, minion0);
-		board.data_.placeMinion(1, minion1);
-		board.data_.placeMinion(1, minion2);
-		board.data_.placeMinion(1, minion3);
+		board.data_.placeCardHandCurrentPlayer(fb);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion2);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion3);
 		
 		board.data_.setMana_p0(3);
 	}
@@ -41,43 +41,43 @@ public class TestArcaneExplosion {
 	@Test
 	public void test0() throws HSException {
 
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 1);
-		res = theCard.useOn(0, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 1);
-		res = theCard.useOn(1, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 2);
-		res = theCard.useOn(1, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 3);
-		res = theCard.useOn(1, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		assertFalse(res == null);
 		assertEquals(res.data_.getMana_p0(), 1);
 		assertEquals(res.data_.getNumCards_hand(), 0);
-		assertEquals(res.data_.getNumMinions_p0(), 1);
-		assertEquals(res.data_.getNumMinions_p1(), 2);
-		assertEquals(res.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(res.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(res.data_.getMinion_p1(0).getHealth(), health0 - 1);
-		assertEquals(res.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(res.data_.getMinion_p1(1).getHealth(), health0 - 1);
-		assertEquals(res.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(res.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(res.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(res.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(res.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0 - 1);
+		assertEquals(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(res.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health0 - 1);
+		assertEquals(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestArcaneIntellect.java
+++ b/src/test/java/com/hearthsim/test/card/TestArcaneIntellect.java
@@ -36,11 +36,11 @@ public class TestArcaneIntellect {
 		Minion minion3 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 
 		ArcaneIntellect fb = new ArcaneIntellect();
-		board.data_.placeCard_hand_p0(fb);
-		board.data_.placeMinion(0, minion0);
-		board.data_.placeMinion(1, minion1);
-		board.data_.placeMinion(1, minion2);
-		board.data_.placeMinion(1, minion3);
+		board.data_.placeCardHandCurrentPlayer(fb);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion2);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion3);
 		
 		board.data_.setMana_p0(5);
 	}
@@ -56,50 +56,50 @@ public class TestArcaneIntellect {
 		
 		Deck deck = new Deck(cards);
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 1);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 1);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 2);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 3);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertEquals(res.data_.getNumCards_hand(), 0);
 		assertTrue(res instanceof CardDrawNode);
 		assertEquals( ((CardDrawNode)res).getNumCardsToDraw(), 2);
 		
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 3);
 		assertTrue(res.data_.getMana_p0() == 2);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(2).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(2).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 	}
 
@@ -113,48 +113,48 @@ public class TestArcaneIntellect {
 		
 		Deck deck = new Deck(cards);
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 1);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 1);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 2);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 3);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertEquals(res.data_.getNumCards_hand(), 0);
 		assertTrue(res instanceof CardDrawNode);
 		assertEquals( ((CardDrawNode)res).getNumCardsToDraw(), 2);
 
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 3);
 		assertTrue(res.data_.getMana_p0() == 2);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(2).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(2).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
 
 	}
 
@@ -187,9 +187,9 @@ public class TestArcaneIntellect {
 		
 		assertEquals( resBoard.getMana_p0(), 0 );
 		assertEquals( resBoard.getMana_p1(), 3 );
-		assertEquals( resBoard.getNumCards_hand_p0(), 2 );
-		assertEquals( resBoard.getNumMinions_p0(), 1 );
-		assertEquals( resBoard.getNumMinions_p1(), 2 );
+		assertEquals( resBoard.getNumCardsHandCurrentPlayer(), 2 );
+		assertEquals( resBoard.getCurrentPlayer().getNumMinions(), 1 );
+		assertEquals( resBoard.getWaitingPlayer().getNumMinions(), 2 );
 	}
 	
 	@Test
@@ -220,9 +220,9 @@ public class TestArcaneIntellect {
 		
 		assertEquals( resBoard.getMana_p0(), 1 );
 		assertEquals( resBoard.getMana_p1(), 6 );
-		assertEquals( resBoard.getNumCards_hand_p0(), 1 );
-		assertEquals( resBoard.getNumMinions_p0(), 2 );
-		assertEquals( resBoard.getNumMinions_p1(), 2 );
+		assertEquals( resBoard.getNumCardsHandCurrentPlayer(), 1 );
+		assertEquals( resBoard.getCurrentPlayer().getNumMinions(), 2 );
+		assertEquals( resBoard.getWaitingPlayer().getNumMinions(), 2 );
 	}
 	
 	@Test
@@ -254,8 +254,8 @@ public class TestArcaneIntellect {
 		
 		assertEquals( resBoard.getMana_p0(), 2 );
 		assertEquals( resBoard.getMana_p1(), 9 );
-		assertEquals( resBoard.getNumCards_hand_p0(), 0 );
-		assertEquals( resBoard.getNumMinions_p0(), 3 );
-		assertEquals( resBoard.getNumMinions_p1(), 2 );
+		assertEquals( resBoard.getNumCardsHandCurrentPlayer(), 0 );
+		assertEquals( resBoard.getCurrentPlayer().getNumMinions(), 3 );
+		assertEquals( resBoard.getWaitingPlayer().getNumMinions(), 2 );
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestAssassinate.java
+++ b/src/test/java/com/hearthsim/test/card/TestAssassinate.java
@@ -31,11 +31,11 @@ public class TestAssassinate {
 		Minion minion3 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 
 		Assassinate fb = new Assassinate();
-		board.data_.placeCard_hand_p0(fb);
-		board.data_.placeMinion(0, minion0);
-		board.data_.placeMinion(1, minion1);
-		board.data_.placeMinion(1, minion2);
-		board.data_.placeMinion(1, minion3);
+		board.data_.placeCardHandCurrentPlayer(fb);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion2);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion3);
 		
 		board.data_.setMana_p0(10);
 	}
@@ -51,37 +51,37 @@ public class TestAssassinate {
 		
 		Deck deck = new Deck(cards);
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 1);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 1);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 2);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 2);
 		assertTrue(res.data_.getMana_p0() == 5);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 	}
 
@@ -95,37 +95,37 @@ public class TestAssassinate {
 		
 		Deck deck = new Deck(cards);
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 1);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 2);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 2);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 2);
 		assertTrue(res.data_.getMana_p0() == 5);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 	}
 	
@@ -140,37 +140,37 @@ public class TestAssassinate {
 		
 		Deck deck = new Deck(cards);
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 1);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(1, 3);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 2);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 2);
 		assertTrue(res.data_.getMana_p0() == 5);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestBackstab.java
+++ b/src/test/java/com/hearthsim/test/card/TestBackstab.java
@@ -30,11 +30,11 @@ public class TestBackstab {
 		Minion minion3 = new Minion("" + 0, mana, attack0, (byte)(health0-2), attack0, health0, health0);
 
 		Backstab fb = new Backstab();
-		board.data_.placeCard_hand_p0(fb);
-		board.data_.placeMinion(0, minion0);
-		board.data_.placeMinion(1, minion1);
-		board.data_.placeMinion(1, minion2);
-		board.data_.placeMinion(1, minion3);
+		board.data_.placeCardHandCurrentPlayer(fb);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion2);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion3);
 		
 		board.data_.setMana_p0(10);
 	}
@@ -45,35 +45,35 @@ public class TestBackstab {
 
 		Deck deck = null;
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
-		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, deck, null);
+
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 
-		target = board.data_.getCharacter(0, 1);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 3);
 		assertTrue(res.data_.getMana_p0() == 10);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(2).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p1(2).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0-2);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0-2);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 	}
 
@@ -83,27 +83,27 @@ public class TestBackstab {
 
 		Deck deck = null;
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 1);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 3);
 		assertTrue(res.data_.getMana_p0() == 10);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(2).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p1(2).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0-2);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0-2);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 	}
 
@@ -113,25 +113,25 @@ public class TestBackstab {
 
 		Deck deck = null;
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 2);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 2);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 2);
 		assertTrue(res.data_.getMana_p0() == 10);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health0-2);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 	}
 	
@@ -141,12 +141,12 @@ public class TestBackstab {
 
 		Deck deck = null;
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 
-		target = board.data_.getCharacter(1, 3);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 
 	}

--- a/src/test/java/com/hearthsim/test/card/TestBite.java
+++ b/src/test/java/com/hearthsim/test/card/TestBite.java
@@ -30,11 +30,11 @@ public class TestBite {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestBite {
 		deck = new Deck(cards);
 
 		Card fb = new Bite();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -54,16 +54,16 @@ public class TestBite {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -77,57 +77,57 @@ public class TestBite {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
-		assertEquals(board.data_.getHero_p0().getArmor(), 4);
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 4);
+		assertEquals(board.data_.getCurrentPlayerHero().getArmor(), 4);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 4);
 	}
 
 }

--- a/src/test/java/com/hearthsim/test/card/TestBlessingOfMight.java
+++ b/src/test/java/com/hearthsim/test/card/TestBlessingOfMight.java
@@ -31,11 +31,11 @@ public class TestBlessingOfMight {
 		Minion minion3 = new Minion("" + 0, mana, attack0, (byte)(health0-2), attack0, health0, health0);
 
 		BlessingOfMight fb = new BlessingOfMight();
-		board.data_.placeCard_hand_p0(fb);
-		board.data_.placeMinion(0, minion0);
-		board.data_.placeMinion(1, minion1);
-		board.data_.placeMinion(1, minion2);
-		board.data_.placeMinion(1, minion3);
+		board.data_.placeCardHandCurrentPlayer(fb);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion2);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion3);
 		
 		board.data_.setMana_p0(10);
 	}
@@ -45,35 +45,35 @@ public class TestBlessingOfMight {
 
 		Deck deck = null;
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 
-		target = board.data_.getCharacter(0, 1);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 3);
 		assertTrue(res.data_.getMana_p0() == 9);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0 + 3);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(2).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p1(2).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0 + 3);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0-2);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 	}
 	
@@ -82,27 +82,27 @@ public class TestBlessingOfMight {
 
 		Deck deck = null;
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 
-		target = board.data_.getCharacter(1, 1);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 3);
 		assertTrue(res.data_.getMana_p0() == 9);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0+3);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(2).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p1(2).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0+3);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0-2);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 	}
 	
 	@Test
@@ -110,26 +110,26 @@ public class TestBlessingOfMight {
 
 		Deck deck = null;
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 
-		target = board.data_.getCharacter(1, 2);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 1);
-		assertTrue(res.data_.getNumMinions_p1() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 3);
 		assertTrue(res.data_.getMana_p0() == 9);
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0+3);
-		assertTrue(res.data_.getMinion_p1(2).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p1(2).getTotalAttack() == attack0);
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0+3);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0-2);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestBloodlust.java
+++ b/src/test/java/com/hearthsim/test/card/TestBloodlust.java
@@ -31,11 +31,11 @@ public class TestBloodlust {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestBloodlust {
 		deck = new Deck(cards);
 
 		Bloodlust fb = new Bloodlust();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)4);
 		board.data_.setMana_p1((byte)4);
@@ -58,86 +58,86 @@ public class TestBloodlust {
 	@Test
 	public void test0() throws HSException {
 
-		Minion target = board.data_.getCharacter(1, 0);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
 
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
         int attackPlus3 = attack0 + 3;
-        assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attackPlus3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attackPlus3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+        assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attackPlus3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attackPlus3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 		
-		Minion theMinion = board.data_.getMinion_p0(0);
-		target = board.data_.getCharacter(1, 0);
-		ret = theMinion.attack(1, target, ret, deck, null);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30 - attackPlus3);
+		Minion theMinion = board.data_.getCurrentPlayer().getMinions().get(0);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		ret = theMinion.attack(ret.data_.getWaitingPlayer(), target, ret, deck, null);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30 - attackPlus3);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
         int attackPlus3 = attack0 + 3;
-        assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attackPlus3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attackPlus3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+        assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attackPlus3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attackPlus3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 		
-		Minion theMinion = board.data_.getMinion_p0(0);
-		target = board.data_.getCharacter(1, 2);
-		ret = theMinion.attack(1, target, ret, deck, null);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0 - attack0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1 - attackPlus3);
+		Minion theMinion = board.data_.getCurrentPlayer().getMinions().get(0);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = theMinion.attack(ret.data_.getWaitingPlayer(), target, ret, deck, null);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0 - attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - attackPlus3);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestCharge.java
+++ b/src/test/java/com/hearthsim/test/card/TestCharge.java
@@ -32,11 +32,11 @@ public class TestCharge {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -49,52 +49,52 @@ public class TestCharge {
 	@Test
 	public void test0() throws HSException {
 		Charge fb = new Charge();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		Charge fb = new Charge();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0 + 2);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0 + 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestClaw.java
+++ b/src/test/java/com/hearthsim/test/card/TestClaw.java
@@ -32,11 +32,11 @@ public class TestClaw {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,89 +46,89 @@ public class TestClaw {
 		deck = new Deck(cards);
 
 		Claw fb = new Claw();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 2);
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getHero_p0().getArmor(), 2);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getArmor(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
-		target = board.data_.getCharacter(1, 1);
-		ret = board.data_.getHero_p0().attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = board.data_.getCurrentPlayerHero().attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 27);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 2);
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getHero_p0().getArmor(), 0);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0 - 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getArmor(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0 - 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
 		
-		board.data_.getHero_p0().endTurn(0, board.data_, deck, null);
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 0);
-		assertEquals(board.data_.getHero_p0().getArmor(), 0);
+		board.data_.getCurrentPlayerHero().endTurn(board.data_.getCurrentPlayer(), board.data_, deck, null);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getArmor(), 0);
 		
 	}
 

--- a/src/test/java/com/hearthsim/test/card/TestConsecration.java
+++ b/src/test/java/com/hearthsim/test/card/TestConsecration.java
@@ -33,11 +33,11 @@ public class TestConsecration {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,46 +47,46 @@ public class TestConsecration {
 		deck = new Deck(cards);
 
 		Consecration fb = new Consecration();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0 - 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1 - 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0 - 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - 2);
 	}
 
 

--- a/src/test/java/com/hearthsim/test/card/TestCorruption.java
+++ b/src/test/java/com/hearthsim/test/card/TestCorruption.java
@@ -33,11 +33,11 @@ public class TestCorruption {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,7 +47,7 @@ public class TestCorruption {
 		deck = new Deck(cards);
 
 		Corruption fb = new Corruption();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)4);
 		board.data_.setMana_p1((byte)4);
@@ -60,66 +60,66 @@ public class TestCorruption {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
 		ret.data_.endTurn(deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
 		ret.data_.startTurn();
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health1 - 1);
 
 	}
 	

--- a/src/test/java/com/hearthsim/test/card/TestDeadlyPoison.java
+++ b/src/test/java/com/hearthsim/test/card/TestDeadlyPoison.java
@@ -34,11 +34,11 @@ public class TestDeadlyPoison {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -48,7 +48,7 @@ public class TestDeadlyPoison {
 		deck = new Deck(cards);
 
 		DeadlyPoison fb = new DeadlyPoison();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
@@ -56,99 +56,99 @@ public class TestDeadlyPoison {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test3() throws HSException {
 		
 		FieryWarAxe fb = new FieryWarAxe();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(1);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(1);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 3);
-		assertEquals(board.data_.getHero_p0().getWeaponCharge(), 2);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getWeaponCharge(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 0);
-		ret = theCard.useOn(0, target, board, deck, null);
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 5);
-		assertEquals(board.data_.getHero_p0().getWeaponCharge(), 2);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getWeaponCharge(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestDivineSpirit.java
+++ b/src/test/java/com/hearthsim/test/card/TestDivineSpirit.java
@@ -31,11 +31,11 @@ public class TestDivineSpirit {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestDivineSpirit {
 		deck = new Deck(cards);
 
 		DivineSpirit fb = new DivineSpirit();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)4);
 		board.data_.setMana_p1((byte)4);
@@ -77,94 +77,94 @@ public class TestDivineSpirit {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0 * 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0 * 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
-		assertEquals(board.data_.getMinion_p0(0).getMaxHealth(), health0 * 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getMaxHealth(), health0 * 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 
 	@Test
 	public void test3() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), (health1 - 1) * 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), (health1 - 1) * 2);
 		
-		assertEquals(board.data_.getMinion_p1(1).getMaxHealth(), health1 + health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getMaxHealth(), health1 + health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestDrainLife.java
+++ b/src/test/java/com/hearthsim/test/card/TestDrainLife.java
@@ -33,11 +33,11 @@ public class TestDrainLife {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -50,80 +50,80 @@ public class TestDrainLife {
 	@Test
 	public void test0() throws HSException {
 		DrainLife fb = new DrainLife();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		DrainLife fb = new DrainLife();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0 - 2);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0 - 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		DrainLife fb = new DrainLife();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		board.data_.getHero_p0().setHealth((byte)15);
+		board.data_.getCurrentPlayerHero().setHealth((byte)15);
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 17); //healed for 2
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0 - 2);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 17); //healed for 2
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0 - 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestExecute.java
+++ b/src/test/java/com/hearthsim/test/card/TestExecute.java
@@ -33,11 +33,11 @@ public class TestExecute {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -50,76 +50,76 @@ public class TestExecute {
 	@Test
 	public void test0() throws HSException {
 		Execute fb = new Execute();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
 	}
 
 	@Test
 	public void test1() throws HSException {
 		Execute fb = new Execute();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		Execute fb = new Execute();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 1);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 1);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestFanOfKnives.java
+++ b/src/test/java/com/hearthsim/test/card/TestFanOfKnives.java
@@ -32,11 +32,11 @@ public class TestFanOfKnives {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestFanOfKnives {
 		deck = new Deck(cards);
 
 		Card fb = new FanOfKnives();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)4);
 		board.data_.setMana_p1((byte)4);
@@ -59,60 +59,60 @@ public class TestFanOfKnives {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0 - 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - 1);
 	}
 
 }

--- a/src/test/java/com/hearthsim/test/card/TestFireball.java
+++ b/src/test/java/com/hearthsim/test/card/TestFireball.java
@@ -28,129 +28,129 @@ public class TestFireball {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, health1, attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 				
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		Fireball fb = new Fireball();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertTrue("test0_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test0_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test0_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test0_4", board.data_.getHero_p0().getHealth() == 24);
-		assertTrue("test0_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test0_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test0_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test0_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test0_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test0_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test0_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test0_4", board.data_.getCurrentPlayerHero().getHealth() == 24);
+		assertTrue("test0_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test0_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test0_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test0_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test0_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		Fireball fb = new Fireball();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test1_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test1_2", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test1_3", board.data_.getHero_p1().getHealth() == 24);
-		assertTrue("test1_4", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test1_5", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test1_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test1_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test1_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test1_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test1_2", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test1_3", board.data_.getWaitingPlayerHero().getHealth() == 24);
+		assertTrue("test1_4", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test1_5", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test1_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test1_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test1_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test1_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		Fireball fb = new Fireball();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertTrue("test2_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test2_2", board.data_.getNumMinions_p0() == 1);
-		assertTrue("test2_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test2_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test2_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test2_6", board.data_.getMinion_p0(0).getHealth() == health1);
-		assertTrue("test2_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test2_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test2_2", board.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue("test2_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test2_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test2_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test2_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health1);
+		assertTrue("test2_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test2_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 	
 	@Test
 	public void test3() throws HSException {
 		Fireball fb = new Fireball();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertTrue("test3_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test3_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test3_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test3_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test3_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test3_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test3_7", board.data_.getMinion_p0(1).getHealth() == health1 - 6);
-		assertTrue("test3_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test3_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test3_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test3_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test3_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test3_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test3_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test3_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 6);
+		assertTrue("test3_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test3_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 	
 	@Test
 	public void test4() throws HSException {
 		Fireball fb = new Fireball();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test4_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test4_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test4_3", board.data_.getNumMinions_p1() == 1);
-		assertTrue("test4_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test4_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test4_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test4_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test4_8", board.data_.getMinion_p1(0).getHealth() == health1);
+		assertTrue("test4_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test4_3", board.data_.getWaitingPlayer().getNumMinions() == 1);
+		assertTrue("test4_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test4_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test4_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test4_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test4_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health1);
 	}
 
 	@Test
 	public void test5() throws HSException {
 		Fireball fb = new Fireball();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test5_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test5_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test5_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test5_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test5_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test5_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test5_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test5_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test5_9", board.data_.getMinion_p1(1).getHealth() == health1 - 6);
+		assertTrue("test5_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test5_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test5_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test5_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test5_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test5_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test5_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test5_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 6);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestFrostShock.java
+++ b/src/test/java/com/hearthsim/test/card/TestFrostShock.java
@@ -32,11 +32,11 @@ public class TestFrostShock {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -49,57 +49,57 @@ public class TestFrostShock {
 	@Test
 	public void test0() throws HSException {
 		FrostShock fb = new FrostShock();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
-		assertFalse(board.data_.getMinion_p0(0).getFrozen());
-		assertFalse(board.data_.getMinion_p1(0).getFrozen());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getFrozen());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(0).getFrozen());
 	}
 
 	@Test
 	public void test1() throws HSException {
 		FrostShock fb = new FrostShock();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0 - 1);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(board.data_.getMinion_p0(0).getCharge());
-		assertFalse(board.data_.getMinion_p0(1).getCharge());
-		assertFalse(board.data_.getMinion_p0(0).getFrozen());
-		assertTrue(board.data_.getMinion_p1(0).getFrozen());
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getCharge());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getFrozen());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getFrozen());
 	}
 
 }

--- a/src/test/java/com/hearthsim/test/card/TestHammerOfWrath.java
+++ b/src/test/java/com/hearthsim/test/card/TestHammerOfWrath.java
@@ -32,11 +32,11 @@ public class TestHammerOfWrath {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -49,55 +49,55 @@ public class TestHammerOfWrath {
 	@Test
 	public void test0() throws HSException {
 		HammerOfWrath fb = new HammerOfWrath();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 1);
-		assertTrue(ret.data_.getNumMinions_p0() == 2);
-		assertTrue(ret.data_.getNumMinions_p1() == 2);
-		assertTrue(ret.data_.getHero_p0().getHealth() == 27);
-		assertTrue(ret.data_.getHero_p1().getHealth() == 30);
-		assertTrue(ret.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(ret.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p1(1).getHealth() == health1 - 1);
-		assertTrue(ret.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(ret.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(ret.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertTrue(ret.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(ret.data_.getMinion_p0(0).getCharge());
-		assertFalse(ret.data_.getMinion_p0(1).getCharge());
-		assertFalse(ret.data_.getMinion_p0(0).getFrozen());
-		assertFalse(ret.data_.getMinion_p1(0).getFrozen());
+		assertTrue(ret.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(ret.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(ret.data_.getCurrentPlayerHero().getHealth() == 27);
+		assertTrue(ret.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(ret.data_.getCurrentPlayer().getMinions().get(0).getCharge());
+		assertFalse(ret.data_.getCurrentPlayer().getMinions().get(1).getCharge());
+		assertFalse(ret.data_.getCurrentPlayer().getMinions().get(0).getFrozen());
+		assertFalse(ret.data_.getWaitingPlayer().getMinions().get(0).getFrozen());
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		HammerOfWrath fb = new HammerOfWrath();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 1);
 
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 1);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p0(0).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertTrue(board.data_.getMinion_p1(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 1);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestHealingTouch.java
+++ b/src/test/java/com/hearthsim/test/card/TestHealingTouch.java
@@ -33,11 +33,11 @@ public class TestHealingTouch {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -51,64 +51,64 @@ public class TestHealingTouch {
 	@Test
 	public void test0() throws HSException {
 		HealingTouch fb = new HealingTouch();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		HealingTouch fb = new HealingTouch();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue( ret instanceof CardDrawNode );
 		assertEquals( ((CardDrawNode)ret).getNumCardsToDraw(), 1);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		HealingTouch fb = new HealingTouch();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue( ret instanceof CardDrawNode );
 		assertEquals( ((CardDrawNode)ret).getNumCardsToDraw(), 1);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestHellfire.java
+++ b/src/test/java/com/hearthsim/test/card/TestHellfire.java
@@ -33,11 +33,11 @@ public class TestHellfire {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,44 +47,44 @@ public class TestHellfire {
 		deck = new Deck(cards);
 
 		Hellfire fb = new Hellfire();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
-		assertEquals(board.data_.getHero_p0().getHealth(), 27);
-		assertEquals(board.data_.getHero_p1().getHealth(), 27);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health1 - 4);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health1 - 4);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health1 - 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health1 - 4);
 	}
 
 

--- a/src/test/java/com/hearthsim/test/card/TestHex.java
+++ b/src/test/java/com/hearthsim/test/card/TestHex.java
@@ -30,11 +30,11 @@ public class TestHex {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestHex {
 		deck = new Deck(cards);
 
 		Hex fb = new Hex();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -54,16 +54,16 @@ public class TestHex {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -78,108 +78,108 @@ public class TestHex {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 		
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 6);
 
-		assertTrue(board.data_.getMinion_p1(0) instanceof Frog);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0) instanceof Frog);
 	}
 
 	@Test
 	public void test3() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 1);
 
-		assertTrue(board.data_.getMinion_p1(1) instanceof Frog);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1) instanceof Frog);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestHolyNova.java
+++ b/src/test/java/com/hearthsim/test/card/TestHolyNova.java
@@ -32,11 +32,11 @@ public class TestHolyNova {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestHolyNova {
 		deck = new Deck(cards);
 
 		Card fb = new HolyNova();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -59,93 +59,93 @@ public class TestHolyNova {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		board.data_.getHero_p0().setHealth((byte)23);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		board.data_.getCurrentPlayerHero().setHealth((byte)23);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 25);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0 - 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1 - 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 25);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0 - 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 
 	@Test
 	public void test3() throws HSException {
 		
-		board.data_.getHero_p0().setHealth((byte)23);
-		board.data_.getMinion_p1(0).setHealth((byte)(board.data_.getMinion_p1(0).getHealth() - 1));
+		board.data_.getCurrentPlayerHero().setHealth((byte)23);
+		board.data_.getWaitingPlayer().getMinions().get(0).setHealth((byte)(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() - 1));
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 25);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health1 - 1 - 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 25);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health1 - 1 - 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
 	}
 
 }

--- a/src/test/java/com/hearthsim/test/card/TestHolySmite.java
+++ b/src/test/java/com/hearthsim/test/card/TestHolySmite.java
@@ -28,129 +28,129 @@ public class TestHolySmite {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, health1, attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 				
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		HolySmite hs = new HolySmite();
-		board.data_.placeCard_hand_p0(hs);
+		board.data_.placeCardHandCurrentPlayer(hs);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertTrue("test0_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test0_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test0_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test0_4", board.data_.getHero_p0().getHealth() == 28);
-		assertTrue("test0_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test0_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test0_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test0_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test0_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test0_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test0_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test0_4", board.data_.getCurrentPlayerHero().getHealth() == 28);
+		assertTrue("test0_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test0_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test0_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test0_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test0_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		HolySmite hs = new HolySmite();
-		board.data_.placeCard_hand_p0(hs);
+		board.data_.placeCardHandCurrentPlayer(hs);
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test1_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test1_2", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test1_3", board.data_.getHero_p1().getHealth() == 28);
-		assertTrue("test1_4", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test1_5", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test1_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test1_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test1_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test1_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test1_2", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test1_3", board.data_.getWaitingPlayerHero().getHealth() == 28);
+		assertTrue("test1_4", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test1_5", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test1_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test1_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test1_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test1_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		HolySmite hs = new HolySmite();
-		board.data_.placeCard_hand_p0(hs);
+		board.data_.placeCardHandCurrentPlayer(hs);
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertTrue("test2_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test2_2", board.data_.getNumMinions_p0() == 1);
-		assertTrue("test2_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test2_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test2_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test2_6", board.data_.getMinion_p0(0).getHealth() == health1);
-		assertTrue("test2_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test2_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test2_2", board.data_.getCurrentPlayer().getNumMinions() == 1);
+		assertTrue("test2_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test2_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test2_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test2_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health1);
+		assertTrue("test2_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test2_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 	
 	@Test
 	public void test3() throws HSException {
 		HolySmite hs = new HolySmite();
-		board.data_.placeCard_hand_p0(hs);
+		board.data_.placeCardHandCurrentPlayer(hs);
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertTrue("test3_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test3_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test3_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test3_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test3_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test3_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test3_7", board.data_.getMinion_p0(1).getHealth() == health1 - 2);
-		assertTrue("test3_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test3_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test3_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test3_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test3_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test3_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test3_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test3_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 2);
+		assertTrue("test3_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test3_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 	
 	@Test
 	public void test4() throws HSException {
 		HolySmite hs = new HolySmite();
-		board.data_.placeCard_hand_p0(hs);
+		board.data_.placeCardHandCurrentPlayer(hs);
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test4_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test4_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test4_3", board.data_.getNumMinions_p1() == 1);
-		assertTrue("test4_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test4_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test4_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test4_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test4_8", board.data_.getMinion_p1(0).getHealth() == health1);
+		assertTrue("test4_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test4_3", board.data_.getWaitingPlayer().getNumMinions() == 1);
+		assertTrue("test4_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test4_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test4_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test4_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test4_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health1);
 	}
 
 	@Test
 	public void test5() throws HSException {
 		HolySmite hs = new HolySmite();
-		board.data_.placeCard_hand_p0(hs);
+		board.data_.placeCardHandCurrentPlayer(hs);
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test5_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test5_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test5_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test5_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test5_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test5_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test5_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test5_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test5_9", board.data_.getMinion_p1(1).getHealth() == health1 - 2);
+		assertTrue("test5_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test5_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test5_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test5_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test5_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test5_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test5_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test5_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 2);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestHumility.java
+++ b/src/test/java/com/hearthsim/test/card/TestHumility.java
@@ -31,11 +31,11 @@ public class TestHumility {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestHumility {
 		deck = new Deck(cards);
 
 		Card fb = new Humility();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -58,66 +58,66 @@ public class TestHumility {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		board.data_.getHero_p0().setHealth((byte)23);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		board.data_.getCurrentPlayerHero().setHealth((byte)23);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 23);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 23);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 
 }

--- a/src/test/java/com/hearthsim/test/card/TestHuntersMark.java
+++ b/src/test/java/com/hearthsim/test/card/TestHuntersMark.java
@@ -32,11 +32,11 @@ public class TestHuntersMark {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestHuntersMark {
 		deck = new Deck(cards);
 
 		Card fb = new HuntersMark();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -59,92 +59,92 @@ public class TestHuntersMark {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		board.data_.getHero_p0().setHealth((byte)23);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		board.data_.getCurrentPlayerHero().setHealth((byte)23);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 23);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 23);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 	
 	@Test
 	public void test3() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		board.data_.getHero_p0().setHealth((byte)23);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		board.data_.getCurrentPlayerHero().setHealth((byte)23);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 23);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 23);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestInnerFire.java
+++ b/src/test/java/com/hearthsim/test/card/TestInnerFire.java
@@ -29,11 +29,11 @@ public class TestInnerFire {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -43,7 +43,7 @@ public class TestInnerFire {
 		deck = new Deck(cards);
 
 		Card fb = new InnerFire();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -53,16 +53,16 @@ public class TestInnerFire {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -76,79 +76,79 @@ public class TestInnerFire {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 		
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 8);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 8);
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestInnerRage.java
+++ b/src/test/java/com/hearthsim/test/card/TestInnerRage.java
@@ -33,12 +33,12 @@ public class TestInnerRage {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_2);
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_2);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -48,7 +48,7 @@ public class TestInnerRage {
 		deck = new Deck(cards);
 
 		Card fb = new InnerRage();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -58,17 +58,17 @@ public class TestInnerRage {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -82,121 +82,121 @@ public class TestInnerRage {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 6);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 9);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 9);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
-		board.data_.placeCard_hand_p0(new Silence());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 1);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new Silence());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 6);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 8);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 8);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test3() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 3);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		
@@ -204,22 +204,22 @@ public class TestInnerRage {
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 1);
 		
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestInnervate.java
+++ b/src/test/java/com/hearthsim/test/card/TestInnervate.java
@@ -31,11 +31,11 @@ public class TestInnervate {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestInnervate {
 		deck = new Deck(cards);
 
 		Innervate fb = new Innervate();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)4);
 		board.data_.setMana_p1((byte)4);
@@ -58,62 +58,62 @@ public class TestInnervate {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 4);
 		assertEquals(board.data_.getMaxMana_p0(), 4);
 		assertEquals(board.data_.getMaxMana_p1(), 4);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
@@ -122,24 +122,24 @@ public class TestInnervate {
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMaxMana_p0((byte)10);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
 		assertEquals(board.data_.getMaxMana_p0(), 10);
 		assertEquals(board.data_.getMaxMana_p1(), 4);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestKillCommand.java
+++ b/src/test/java/com/hearthsim/test/card/TestKillCommand.java
@@ -34,11 +34,11 @@ public class TestKillCommand {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -48,7 +48,7 @@ public class TestKillCommand {
 		deck = new Deck(cards);
 
 		Card fb = new KillCommand();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -61,65 +61,65 @@ public class TestKillCommand {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 27);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health1 - 1);
 	}
 	
 
 	@Test
 	public void test2() throws HSException {
 		
-		board.data_.placeMinion(0, new IronfurGrizzly());
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), new IronfurGrizzly());
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 25);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 25);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestMarkOfTheWild.java
+++ b/src/test/java/com/hearthsim/test/card/TestMarkOfTheWild.java
@@ -31,11 +31,11 @@ public class TestMarkOfTheWild {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestMarkOfTheWild {
 		deck = new Deck(cards);
 
 		MarkOfTheWild fb = new MarkOfTheWild();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)4);
 		board.data_.setMana_p1((byte)4);
@@ -58,70 +58,70 @@ public class TestMarkOfTheWild {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 4);
 		assertEquals(board.data_.getMaxMana_p0(), 4);
 		assertEquals(board.data_.getMaxMana_p1(), 4);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0 + 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0 + 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
-		assertTrue(board.data_.getMinion_p0(0).getTaunt());
-		assertFalse(board.data_.getMinion_p0(1).getTaunt());
-		assertFalse(board.data_.getMinion_p1(0).getTaunt());
-		assertFalse(board.data_.getMinion_p1(1).getTaunt());
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0 + 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0 + 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTaunt());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getTaunt());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(0).getTaunt());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(1).getTaunt());
 	}
 	
 

--- a/src/test/java/com/hearthsim/test/card/TestMindControl.java
+++ b/src/test/java/com/hearthsim/test/card/TestMindControl.java
@@ -32,11 +32,11 @@ public class TestMindControl {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestMindControl {
 		deck = new Deck(cards);
 
 		Card fb = new MindControl();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)4);
@@ -59,63 +59,63 @@ public class TestMindControl {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 0);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health1 - 1);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestMirroImage.java
+++ b/src/test/java/com/hearthsim/test/card/TestMirroImage.java
@@ -33,11 +33,11 @@ public class TestMirroImage {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,7 +47,7 @@ public class TestMirroImage {
 		deck = new Deck(cards);
 
 		Card fb = new MirrorImage();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)4);
@@ -60,73 +60,73 @@ public class TestMirroImage {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 4);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 9);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(3).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 0);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 0);
 
-		assertTrue(board.data_.getMinion_p0(2) instanceof MirrorImageMinion);
-		assertTrue(board.data_.getMinion_p0(3) instanceof MirrorImageMinion);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2) instanceof MirrorImageMinion);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(3) instanceof MirrorImageMinion);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestMortalCoil.java
+++ b/src/test/java/com/hearthsim/test/card/TestMortalCoil.java
@@ -33,11 +33,11 @@ public class TestMortalCoil {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,7 +47,7 @@ public class TestMortalCoil {
 		deck = new Deck(cards);
 
 		Card fb = new MortalCoil();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)4);
@@ -60,89 +60,89 @@ public class TestMortalCoil {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 9);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - 1);
 
 	}
 	
 	@Test
 	public void test3() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 1);
 
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 9);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health1 - 1);
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestNightblade.java
+++ b/src/test/java/com/hearthsim/test/card/TestNightblade.java
@@ -31,11 +31,11 @@ public class TestNightblade {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestNightblade {
 		deck = new Deck(cards);
 
 		Card fb = new Nightblade();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)4);
@@ -58,67 +58,67 @@ public class TestNightblade {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 27);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 27);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestRockbiterWeapon.java
+++ b/src/test/java/com/hearthsim/test/card/TestRockbiterWeapon.java
@@ -32,11 +32,11 @@ public class TestRockbiterWeapon {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestRockbiterWeapon {
 		deck = new Deck(cards);
 
 		Card fb = new RockbiterWeapon();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)4);
@@ -59,80 +59,80 @@ public class TestRockbiterWeapon {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 9);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 3);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
-		target = board.data_.getCharacter(1, 2);
-		ret = board.data_.getHero_p0().attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = board.data_.getCurrentPlayerHero().attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 9);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 3);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30 - attack0);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1 - 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30 - attack0);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - 3);
 	}
 	
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 9);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 0);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
-		assertEquals(board.data_.getMinion_p0(0).getExtraAttackUntilTurnEnd(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 3);
 
 		
-		target = board.data_.getCharacter(1, 2);
-		ret = board.data_.getMinion_p0(0).attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = board.data_.getCurrentPlayer().getMinions().get(0).attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 9);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1 - attack0 - 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - attack0 - 3);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestSacrificialPact.java
+++ b/src/test/java/com/hearthsim/test/card/TestSacrificialPact.java
@@ -32,11 +32,11 @@ public class TestSacrificialPact {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Demon("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestSacrificialPact {
 		deck = new Deck(cards);
 
 		Card fb = new SacrificialPact();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)4);
@@ -59,62 +59,62 @@ public class TestSacrificialPact {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestSap.java
+++ b/src/test/java/com/hearthsim/test/card/TestSap.java
@@ -30,11 +30,11 @@ public class TestSap {
 		Minion minion1_0 = new BloodfenRaptor();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestSap {
 		deck = new Deck(cards);
 
 		Card fb = new Sap();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)10);
@@ -54,16 +54,16 @@ public class TestSap {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -75,138 +75,138 @@ public class TestSap {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumCards_hand_p1(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getNumCardsHandWaitingPlayer(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
 		
-		assertTrue(board.data_.getCard_hand_p1(0) instanceof RaidLeader);
+		assertTrue(board.data_.getWaitingPlayerCardHand(0) instanceof RaidLeader);
 	}
 
 	@Test
 	public void test3() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumCards_hand_p1(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getNumCardsHandWaitingPlayer(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
 
-		assertTrue(board.data_.getCard_hand_p1(0) instanceof BloodfenRaptor);
+		assertTrue(board.data_.getWaitingPlayerCardHand(0) instanceof BloodfenRaptor);
 	}
 
 	@Test
 	public void test4() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
 		for (int indx = 0; indx < 10; ++indx) 
-			board.data_.placeCard_hand_p1(new TheCoin());
+			board.data_.placeCardHandWaitingPlayer(new TheCoin());
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumCards_hand_p1(), 10);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getNumCardsHandWaitingPlayer(), 10);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
 
 		for (int indx = 0; indx < 10; ++indx) 
-			assertTrue(board.data_.getCard_hand_p1(0) instanceof TheCoin);
+			assertTrue(board.data_.getWaitingPlayerCardHand(0) instanceof TheCoin);
 
 	}
 

--- a/src/test/java/com/hearthsim/test/card/TestSavageRoar.java
+++ b/src/test/java/com/hearthsim/test/card/TestSavageRoar.java
@@ -30,11 +30,11 @@ public class TestSavageRoar {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestSavageRoar {
 		deck = new Deck(cards);
 
 		Card fb = new SavageRoar();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)10);
@@ -54,16 +54,16 @@ public class TestSavageRoar {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -76,136 +76,136 @@ public class TestSavageRoar {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 9);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 9);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getHero_p1().getExtraAttackUntilTurnEnd(), 0);
-		assertEquals(board.data_.getMinion_p0(0).getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getExtraAttackUntilTurnEnd(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getWaitingPlayerHero().getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getExtraAttackUntilTurnEnd(), 0);
 		
-		target = board.data_.getCharacter(1, 2);
-		ret = board.data_.getMinion_p0(0).attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = board.data_.getCurrentPlayer().getMinions().get(0).attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 8);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 8);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getHero_p1().getExtraAttackUntilTurnEnd(), 0);
-		assertEquals(board.data_.getMinion_p0(0).getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getExtraAttackUntilTurnEnd(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getWaitingPlayerHero().getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getExtraAttackUntilTurnEnd(), 0);
 		
-		target = board.data_.getCharacter(1, 2);
-		ret = board.data_.getHero_p0().attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = board.data_.getCurrentPlayerHero().attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 23);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 23);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 8);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 8);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getHero_p1().getExtraAttackUntilTurnEnd(), 0);
-		assertEquals(board.data_.getMinion_p0(0).getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getExtraAttackUntilTurnEnd(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getWaitingPlayerHero().getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getExtraAttackUntilTurnEnd(), 0);
 
 	}
 

--- a/src/test/java/com/hearthsim/test/card/TestShadowWordDeath.java
+++ b/src/test/java/com/hearthsim/test/card/TestShadowWordDeath.java
@@ -29,11 +29,11 @@ public class TestShadowWordDeath {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -43,7 +43,7 @@ public class TestShadowWordDeath {
 		deck = new Deck(cards);
 
 		Card fb = new ShadowWordDeath();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)10);
@@ -53,16 +53,16 @@ public class TestShadowWordDeath {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -75,76 +75,76 @@ public class TestShadowWordDeath {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestShadowWordPain.java
+++ b/src/test/java/com/hearthsim/test/card/TestShadowWordPain.java
@@ -30,11 +30,11 @@ public class TestShadowWordPain {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestShadowWordPain {
 		deck = new Deck(cards);
 
 		Card fb = new ShadowWordPain();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)10);
@@ -54,16 +54,16 @@ public class TestShadowWordPain {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -76,76 +76,76 @@ public class TestShadowWordPain {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestSlam.java
+++ b/src/test/java/com/hearthsim/test/card/TestSlam.java
@@ -31,11 +31,11 @@ public class TestSlam {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestSlam {
 		deck = new Deck(cards);
 
 		Card fb = new Slam();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)10);
@@ -55,16 +55,16 @@ public class TestSlam {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -78,54 +78,54 @@ public class TestSlam {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 1);
@@ -135,27 +135,27 @@ public class TestSlam {
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 1);
@@ -165,25 +165,25 @@ public class TestSlam {
 	@Test
 	public void test3() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
 		
 		assertFalse(ret instanceof CardDrawNode);
 	}

--- a/src/test/java/com/hearthsim/test/card/TestSwipe.java
+++ b/src/test/java/com/hearthsim/test/card/TestSwipe.java
@@ -30,11 +30,11 @@ public class TestSwipe {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestSwipe {
 		deck = new Deck(cards);
 
 		Card fb = new Swipe();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)10);
 		board.data_.setMana_p1((byte)10);
@@ -54,16 +54,16 @@ public class TestSwipe {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -77,103 +77,103 @@ public class TestSwipe {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2 - 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test3() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30 - 1);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 7 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 7 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
 	}
 }

--- a/src/test/java/com/hearthsim/test/card/TestWildGrowth.java
+++ b/src/test/java/com/hearthsim/test/card/TestWildGrowth.java
@@ -31,11 +31,11 @@ public class TestWildGrowth {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestWildGrowth {
 		deck = new Deck(cards);
 
 		Card fb = new WildGrowth();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -55,16 +55,16 @@ public class TestWildGrowth {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -78,83 +78,83 @@ public class TestWildGrowth {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 
 
 	@Test
 	public void test2() throws HSException {
 				
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
 		assertEquals(board.data_.getMaxMana_p0(), 9);
 		assertEquals(board.data_.getMaxMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
@@ -167,29 +167,29 @@ public class TestWildGrowth {
 		board.data_.setMaxMana_p1((byte)10);
 		
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertTrue(board.data_.getCard_hand_p0(0) instanceof ExcessMana);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertTrue(board.data_.getCurrentPlayerCardHand(0) instanceof ExcessMana);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
 		assertEquals(board.data_.getMaxMana_p0(), 10);
 		assertEquals(board.data_.getMaxMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestDruid.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestDruid.java
@@ -31,11 +31,11 @@ public class TestDruid {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestDruid {
 		deck = new Deck(cards);
 
 		Card fb = new WildGrowth();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -55,16 +55,16 @@ public class TestDruid {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -78,92 +78,92 @@ public class TestDruid {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
-		target = board.data_.getCharacter(1, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(0, 0);
-		ret = hero.useHeroAbility(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		ret = hero.useHeroAbility(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getHero_p0().getArmor(), 1);
-		assertEquals(board.data_.getHero_p1().getArmor(), 0);
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 1);
-		assertEquals(board.data_.getHero_p1().getTotalAttack(), 0);
-		assertEquals(board.data_.getHero_p0().getExtraAttackUntilTurnEnd(), 1);
-		assertEquals(board.data_.getHero_p1().getExtraAttackUntilTurnEnd(), 0);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayerHero().getArmor(), 1);
+		assertEquals(board.data_.getWaitingPlayerHero().getArmor(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayerHero().getTotalAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getExtraAttackUntilTurnEnd(), 1);
+		assertEquals(board.data_.getWaitingPlayerHero().getExtraAttackUntilTurnEnd(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestHunter.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestHunter.java
@@ -32,11 +32,11 @@ public class TestHunter {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestHunter {
 		deck = new Deck(cards);
 
 		Card fb = new WildGrowth();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -56,16 +56,16 @@ public class TestHunter {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -79,85 +79,85 @@ public class TestHunter {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
-		target = board.data_.getCharacter(1, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestMage.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestMage.java
@@ -31,11 +31,11 @@ public class TestMage {
 		Minion minion1_0 = new ChillwindYeti();
 		Minion minion1_1 = new ChillwindYeti();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -52,16 +52,16 @@ public class TestMage {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -75,86 +75,86 @@ public class TestMage {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
 		
-		target = board.data_.getCharacter(1, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 25);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 25);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 25);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 25);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 25);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 25);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestPaladin.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestPaladin.java
@@ -33,11 +33,11 @@ public class TestPaladin {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,7 +47,7 @@ public class TestPaladin {
 		deck = new Deck(cards);
 
 		Card fb = new WildGrowth();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -57,16 +57,16 @@ public class TestPaladin {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -80,86 +80,86 @@ public class TestPaladin {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
-		Hero hero = board.data_.getHero_p0();
-		target = board.data_.getCharacter(1, 0);
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(0, 0);
-		ret = hero.useHeroAbility(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		ret = hero.useHeroAbility(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestPriest.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestPriest.java
@@ -32,11 +32,11 @@ public class TestPriest {
 		Minion minion1_0 = new ChillwindYeti();
 		Minion minion1_1 = new ChillwindYeti();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -53,16 +53,16 @@ public class TestPriest {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -76,88 +76,88 @@ public class TestPriest {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
 		
-		target = board.data_.getCharacter(1, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
 	}
 	
@@ -181,19 +181,19 @@ public class TestPriest {
 
 		assertFalse(tree == null);
 		assertEquals(bestPlay.data_.getNumCards_hand(), 0);
-		assertEquals(bestPlay.data_.getNumMinions_p0(), 2);
-		assertEquals(bestPlay.data_.getNumMinions_p1(), 1);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(bestPlay.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(bestPlay.data_.getMana_p0(), 6);
 		assertEquals(bestPlay.data_.getMana_p1(), 8);
-		assertEquals(bestPlay.data_.getHero_p0().getHealth(), 30);
-		assertEquals(bestPlay.data_.getHero_p1().getHealth(), 30);
-		assertEquals(bestPlay.data_.getMinion_p0(0).getHealth(), 3);
-		assertEquals(bestPlay.data_.getMinion_p0(1).getHealth(), 1);
-		assertEquals(bestPlay.data_.getMinion_p1(0).getHealth(), 5);
+		assertEquals(bestPlay.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(bestPlay.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 3);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+		assertEquals(bestPlay.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
 
-		assertEquals(bestPlay.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(bestPlay.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(bestPlay.data_.getMinion_p1(0).getTotalAttack(), 4);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(bestPlay.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
 		
 	}
 	
@@ -202,7 +202,7 @@ public class TestPriest {
 		
 		
 		//one of your yeti is damaged
-		board.data_.getMinion_p0(0).setHealth((byte)3);
+		board.data_.getCurrentPlayer().getMinions().get(0).setHealth((byte)3);
 		
 
 		
@@ -221,19 +221,19 @@ public class TestPriest {
 
 		assertFalse(tree == null);
 		assertEquals(bestPlay.data_.getNumCards_hand(), 0);
-		assertEquals(bestPlay.data_.getNumMinions_p0(), 2);
-		assertEquals(bestPlay.data_.getNumMinions_p1(), 1);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(bestPlay.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(bestPlay.data_.getMana_p0(), 6);
 		assertEquals(bestPlay.data_.getMana_p1(), 8);
-		assertEquals(bestPlay.data_.getHero_p0().getHealth(), 30);
-		assertEquals(bestPlay.data_.getHero_p1().getHealth(), 30);
-		assertEquals(bestPlay.data_.getMinion_p0(0).getHealth(), 1);
-		assertEquals(bestPlay.data_.getMinion_p0(1).getHealth(), 1);
-		assertEquals(bestPlay.data_.getMinion_p1(0).getHealth(), 5);
+		assertEquals(bestPlay.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(bestPlay.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+		assertEquals(bestPlay.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 5);
 
-		assertEquals(bestPlay.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(bestPlay.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(bestPlay.data_.getMinion_p1(0).getTotalAttack(), 4);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(bestPlay.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(bestPlay.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestRogue.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestRogue.java
@@ -31,11 +31,11 @@ public class TestRogue {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestRogue {
 		deck = new Deck(cards);
 
 		Card fb = new WildGrowth();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -55,16 +55,16 @@ public class TestRogue {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -78,92 +78,92 @@ public class TestRogue {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
-		target = board.data_.getCharacter(1, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(0, 0);
-		ret = hero.useHeroAbility(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		ret = hero.useHeroAbility(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getHero_p0().getArmor(), 0);
-		assertEquals(board.data_.getHero_p1().getArmor(), 0);
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 1);
-		assertEquals(board.data_.getHero_p1().getTotalAttack(), 0);
-		assertEquals(board.data_.getHero_p0().getWeaponCharge(), 2);
-		assertEquals(board.data_.getHero_p1().getWeaponCharge(), 0);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayerHero().getArmor(), 0);
+		assertEquals(board.data_.getWaitingPlayerHero().getArmor(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayerHero().getTotalAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getWeaponCharge(), 2);
+		assertEquals(board.data_.getWaitingPlayerHero().getWeaponCharge(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestShaman.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestShaman.java
@@ -36,11 +36,11 @@ public class TestShaman {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[30];
 		for (int index = 0; index < 30; ++index) {
@@ -50,7 +50,7 @@ public class TestShaman {
 		deck = new Deck(cards);
 
 		Card fb = new WildGrowth();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -60,16 +60,16 @@ public class TestShaman {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -83,141 +83,141 @@ public class TestShaman {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
-		target = board.data_.getCharacter(0, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
 		
 		assertTrue(ret instanceof RandomEffectNode);
 		assertEquals(ret.getChildren().size(), 4);
 		
 		
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 
 		HearthTreeNode cn0 = ret.getChildren().get(0);
-		assertEquals(cn0.data_.getNumMinions_p0(), 3);
-		assertEquals(cn0.data_.getNumMinions_p1(), 2);
+		assertEquals(cn0.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(cn0.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(cn0.data_.getMana_p0(), 6);
 		assertEquals(cn0.data_.getMana_p1(), 8);
-		assertEquals(cn0.data_.getHero_p0().getHealth(), 30);
-		assertEquals(cn0.data_.getHero_p1().getHealth(), 28);
+		assertEquals(cn0.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(cn0.data_.getWaitingPlayerHero().getHealth(), 28);
 		
-		assertTrue(cn0.data_.getMinion_p0(2) instanceof SearingTotem);
+		assertTrue(cn0.data_.getCurrentPlayer().getMinions().get(2) instanceof SearingTotem);
 		
-		assertEquals(cn0.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(cn0.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(cn0.data_.getMinion_p0(2).getTotalHealth(), 1);
-		assertEquals(cn0.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(cn0.data_.getMinion_p1(1).getTotalHealth(), 7);
+		assertEquals(cn0.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn0.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(cn0.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 1);
+		assertEquals(cn0.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn0.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
 
-		assertEquals(cn0.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(cn0.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(cn0.data_.getMinion_p0(2).getTotalAttack(), 2);
-		assertEquals(cn0.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(cn0.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(cn0.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn0.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(cn0.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(cn0.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn0.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		HearthTreeNode cn1 = ret.getChildren().get(1);
-		assertEquals(cn1.data_.getNumMinions_p0(), 3);
-		assertEquals(cn1.data_.getNumMinions_p1(), 2);
+		assertEquals(cn1.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(cn1.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(cn1.data_.getMana_p0(), 6);
 		assertEquals(cn1.data_.getMana_p1(), 8);
-		assertEquals(cn1.data_.getHero_p0().getHealth(), 30);
-		assertEquals(cn1.data_.getHero_p1().getHealth(), 28);
+		assertEquals(cn1.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(cn1.data_.getWaitingPlayerHero().getHealth(), 28);
 		
-		assertTrue(cn1.data_.getMinion_p0(2) instanceof StoneclawTotem);
+		assertTrue(cn1.data_.getCurrentPlayer().getMinions().get(2) instanceof StoneclawTotem);
 		
-		assertEquals(cn1.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(cn1.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(cn1.data_.getMinion_p0(2).getTotalHealth(), 2);
-		assertEquals(cn1.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(cn1.data_.getMinion_p1(1).getTotalHealth(), 7);
+		assertEquals(cn1.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn1.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(cn1.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(cn1.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn1.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
 
-		assertEquals(cn1.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(cn1.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(cn1.data_.getMinion_p0(2).getTotalAttack(), 1);
-		assertEquals(cn1.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(cn1.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(cn1.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn1.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(cn1.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 1);
+		assertEquals(cn1.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn1.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		HearthTreeNode cn2 = ret.getChildren().get(2);
-		assertEquals(cn2.data_.getNumMinions_p0(), 3);
-		assertEquals(cn2.data_.getNumMinions_p1(), 2);
+		assertEquals(cn2.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(cn2.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(cn2.data_.getMana_p0(), 6);
 		assertEquals(cn2.data_.getMana_p1(), 8);
-		assertEquals(cn2.data_.getHero_p0().getHealth(), 30);
-		assertEquals(cn2.data_.getHero_p1().getHealth(), 28);
+		assertEquals(cn2.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(cn2.data_.getWaitingPlayerHero().getHealth(), 28);
 		
-		assertTrue(cn2.data_.getMinion_p0(2) instanceof HealingTotem);
+		assertTrue(cn2.data_.getCurrentPlayer().getMinions().get(2) instanceof HealingTotem);
 		
-		assertEquals(cn2.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(cn2.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(cn2.data_.getMinion_p0(2).getTotalHealth(), 2);
-		assertEquals(cn2.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(cn2.data_.getMinion_p1(1).getTotalHealth(), 7);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
 
-		assertEquals(cn2.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(cn2.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(cn2.data_.getMinion_p0(2).getTotalAttack(), 1);
-		assertEquals(cn2.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(cn2.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 1);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		HearthTreeNode cn3 = ret.getChildren().get(3);
-		assertEquals(cn3.data_.getNumMinions_p0(), 3);
-		assertEquals(cn3.data_.getNumMinions_p1(), 2);
+		assertEquals(cn3.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(cn3.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(cn3.data_.getMana_p0(), 6);
 		assertEquals(cn3.data_.getMana_p1(), 8);
-		assertEquals(cn3.data_.getHero_p0().getHealth(), 30);
-		assertEquals(cn3.data_.getHero_p1().getHealth(), 28);
+		assertEquals(cn3.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(cn3.data_.getWaitingPlayerHero().getHealth(), 28);
 		
-		assertTrue(cn3.data_.getMinion_p0(2) instanceof WrathOfAirTotem);
+		assertTrue(cn3.data_.getCurrentPlayer().getMinions().get(2) instanceof WrathOfAirTotem);
 		
-		assertEquals(cn3.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(cn3.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(cn3.data_.getMinion_p0(2).getTotalHealth(), 2);
-		assertEquals(cn3.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(cn3.data_.getMinion_p1(1).getTotalHealth(), 7);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
 
-		assertEquals(cn3.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(cn3.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(cn3.data_.getMinion_p0(2).getTotalAttack(), 1);
-		assertEquals(cn3.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(cn3.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 1);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		 
 
 		RandomEffectNode rn = (RandomEffectNode)ret;
@@ -240,9 +240,9 @@ public class TestShaman {
 
 		assertEquals(resBoard.getMana_p0(), 6);
 		assertEquals(resBoard.getMana_p1(), 8);
-		assertEquals(resBoard.getNumMinions_p0(), 3);
-		assertEquals(resBoard.getNumMinions_p1(), 1);
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 1);
 
-		log.info("{}",resBoard.getMinion_p0(2).getClass());
+		log.info("{}",resBoard.getCurrentPlayer().getMinions().get(2).getClass());
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestWarlock.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestWarlock.java
@@ -34,11 +34,11 @@ public class TestWarlock {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[30];
 		for (int index = 0; index < 30; ++index) {
@@ -48,7 +48,7 @@ public class TestWarlock {
 		deck = new Deck(cards);
 
 		Card fb = new WildGrowth();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -58,16 +58,16 @@ public class TestWarlock {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -80,79 +80,79 @@ public class TestWarlock {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
-		target = board.data_.getCharacter(0, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
 		
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 1);
 		
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 28);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 
@@ -160,9 +160,9 @@ public class TestWarlock {
 		
 		board.data_.setDeckPos_p0(30);
 		
-		target = board.data_.getCharacter(0, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
 		
 		assertTrue(ret instanceof CardDrawNode);
@@ -172,21 +172,21 @@ public class TestWarlock {
 		double cardDrawScore = ((CardDrawNode)ret).cardDrawScore(deck, ai0);
 		assertTrue(cardDrawScore < 0.0);		
 		
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 28);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/heroes/TestWarrior.java
+++ b/src/test/java/com/hearthsim/test/heroes/TestWarrior.java
@@ -31,11 +31,11 @@ public class TestWarrior {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestWarrior {
 		deck = new Deck(cards);
 
 		Card fb = new WildGrowth();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -55,16 +55,16 @@ public class TestWarrior {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -78,88 +78,88 @@ public class TestWarrior {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Minion minion = board.data_.getMinion_p0(0);
-		HearthTreeNode ret = minion.attack(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(0);
+		HearthTreeNode ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
-		target = board.data_.getCharacter(1, 0);
-		Hero hero = board.data_.getHero_p0();
-		ret = hero.useHeroAbility(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Hero hero = board.data_.getCurrentPlayerHero();
+		ret = hero.useHeroAbility(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		ret = minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(0, 0);
-		ret = hero.useHeroAbility(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		ret = hero.useHeroAbility(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getHero_p0().getArmor(), 2);
-		assertEquals(board.data_.getHero_p1().getArmor(), 0);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayerHero().getArmor(), 2);
+		assertEquals(board.data_.getWaitingPlayerHero().getArmor(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestAbomination.java
+++ b/src/test/java/com/hearthsim/test/minion/TestAbomination.java
@@ -31,12 +31,12 @@ public class TestAbomination {
 		Minion minion1_1 = new RaidLeader();
 		Minion minion1_2 = new ScarletCrusader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestAbomination {
 		deck = new Deck(cards);
 
 		Card fb = new Abomination();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -56,17 +56,17 @@ public class TestAbomination {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -80,119 +80,119 @@ public class TestAbomination {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 		
 		//attack the Ogre... should kill everything except the Scarlet Crusader
-		target = board.data_.getCharacter(1, 3);
-		Minion attacker = board.data_.getCharacter(0, 1);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		Minion attacker = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
 		attacker.hasAttacked(false);
-		ret = attacker.attack(1, target, ret, null, null);
+		ret = attacker.attack(ret.data_.getWaitingPlayer(), target, ret, null, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 1);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 28);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
 		
-		assertFalse(board.data_.getMinion_p1(0).getDivineShield());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 
 	}
 	
@@ -200,61 +200,61 @@ public class TestAbomination {
 	public void test3() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 		
 		//Silence the Abomination first, then attack with it
-		target = board.data_.getCharacter(1, 3);
-		Minion attacker = board.data_.getCharacter(0, 1);
-		attacker.silenced(0, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		Minion attacker = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		attacker.silenced(board.data_.getCurrentPlayer(), board, null, null);
 		attacker.hasAttacked(false);
-		ret = attacker.attack(1, target, ret, null, null);
+		ret = attacker.attack(ret.data_.getWaitingPlayer(), target, ret, null, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestAbusiveSergeant.java
+++ b/src/test/java/com/hearthsim/test/minion/TestAbusiveSergeant.java
@@ -31,12 +31,12 @@ public class TestAbusiveSergeant {
 		Minion minion1_1 = new RaidLeader();
 		Minion minion1_2 = new ScarletCrusader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestAbusiveSergeant {
 		deck = new Deck(cards);
 
 		Card fb = new AbusiveSergeant();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -56,17 +56,17 @@ public class TestAbusiveSergeant {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -82,96 +82,96 @@ public class TestAbusiveSergeant {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 
 		//At this point, the BoardState should have 5 children: 2 buffs on friendly side
 		//and 3 buffs on enemy side
 		assertEquals(board.numChildren(), 5);
 		
-		assertEquals(board.getChildren().get(0).data_.getMinion_p0(0).getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.getChildren().get(1).data_.getMinion_p0(1).getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.getChildren().get(2).data_.getMinion_p1(0).getExtraAttackUntilTurnEnd(), 2);
-		assertEquals(board.getChildren().get(3).data_.getMinion_p1(1).getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.getChildren().get(1).data_.getCurrentPlayer().getMinions().get(1).getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.getChildren().get(2).data_.getWaitingPlayer().getMinions().get(0).getExtraAttackUntilTurnEnd(), 2);
+		assertEquals(board.getChildren().get(3).data_.getWaitingPlayer().getMinions().get(1).getExtraAttackUntilTurnEnd(), 2);
 		
 		//make sure that the extra attack is working!
 		HearthTreeNode child1 = board.getChildren().get(0);
-		target = child1.data_.getCharacter(1, 0);
-		Minion minion = child1.data_.getMinion_p0(0);
-		minion.attack(1, target, child1, deck, null);
+		target = child1.data_.getCharacter(child1.data_.getWaitingPlayer(), 0);
+		Minion minion = child1.data_.getCurrentPlayer().getMinions().get(0);
+		minion.attack(child1.data_.getWaitingPlayer(), target, child1, deck, null);
 		assertEquals(child1.data_.getNumCards_hand(), 0);
-		assertEquals(child1.data_.getNumMinions_p0(), 3);
-		assertEquals(child1.data_.getNumMinions_p1(), 3);
+		assertEquals(child1.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(child1.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(child1.data_.getMana_p0(), 7);
 		assertEquals(child1.data_.getMana_p1(), 8);
-		assertEquals(child1.data_.getHero_p0().getHealth(), 30);
-		assertEquals(child1.data_.getHero_p1().getHealth(), 26);
-		assertEquals(child1.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(child1.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(child1.data_.getMinion_p0(2).getHealth(), 1);
-		assertEquals(child1.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(child1.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(child1.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(child1.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(child1.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(child1.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(child1.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(child1.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 1);
+		assertEquals(child1.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(child1.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(child1.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(child1.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(child1.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(child1.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(child1.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(child1.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(child1.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(child1.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(child1.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(child1.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(child1.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(child1.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(child1.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestAcidicSwampOoze.java
+++ b/src/test/java/com/hearthsim/test/minion/TestAcidicSwampOoze.java
@@ -32,11 +32,11 @@ public class TestAcidicSwampOoze {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestAcidicSwampOoze {
 		deck = new Deck(cards);
 
 		AcidicSwampOoze fb = new AcidicSwampOoze();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)4);
 		board.data_.setMana_p1((byte)4);
@@ -59,76 +59,76 @@ public class TestAcidicSwampOoze {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 		
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test3() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
 		HearthTreeNode fl = new HearthTreeNode(board.data_.flipPlayers());
-		fl.data_.placeCard_hand_p0(new FieryWarAxe());
-		fl = fl.data_.getCard_hand_p0(0).useOn(0, target, fl, deck, null);
+		fl.data_.placeCardHandCurrentPlayer(new FieryWarAxe());
+		fl = fl.data_.getCurrentPlayerCardHand(0).useOn(fl.data_.getCurrentPlayer(), target, fl, deck, null);
 		board = new HearthTreeNode(fl.data_.flipPlayers());
 		
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 0);
-		assertEquals(board.data_.getHero_p0().getWeaponCharge(), 0);
-		assertEquals(board.data_.getHero_p1().getTotalAttack(), 3);
-		assertEquals(board.data_.getHero_p1().getWeaponCharge(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getWeaponCharge(), 0);
+		assertEquals(board.data_.getWaitingPlayerHero().getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayerHero().getWeaponCharge(), 2);
 
-		target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 
-		assertEquals(board.data_.getHero_p0().getTotalAttack(), 0);
-		assertEquals(board.data_.getHero_p0().getWeaponCharge(), 0);
-		assertEquals(board.data_.getHero_p1().getTotalAttack(), 0);
-		assertEquals(board.data_.getHero_p1().getWeaponCharge(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayerHero().getWeaponCharge(), 0);
+		assertEquals(board.data_.getWaitingPlayerHero().getTotalAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayerHero().getWeaponCharge(), 0);
 
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestAcolyteOfPain.java
+++ b/src/test/java/com/hearthsim/test/minion/TestAcolyteOfPain.java
@@ -32,11 +32,11 @@ public class TestAcolyteOfPain {
 		Minion minion1_0 = new GoldshireFootman();
 		Minion minion1_1 = new GoldshireFootman();
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestAcolyteOfPain {
 		deck = new Deck(cards);
 
 		Minion fb = new AcolyteOfPain();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)7);
@@ -59,48 +59,48 @@ public class TestAcolyteOfPain {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
 	}
 	
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 7);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 1);
 	}
 	
 	@Test
@@ -123,13 +123,13 @@ public class TestAcolyteOfPain {
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 2); //1 card drawn from AcolyteOfPain, not enough mana to play it
-		assertEquals(resBoard.getNumMinions_p0(), 2);
-		assertEquals(resBoard.getNumMinions_p1(), 1); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 2); //1 card drawn from AcolyteOfPain, not enough mana to play it
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 1); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 1); //0 mana used
 		assertEquals(resBoard.getMana_p1(), 1);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 30);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 30);
 	}
 	
 	@Test
@@ -151,13 +151,13 @@ public class TestAcolyteOfPain {
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1, 200000000);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 1); //1 card drawn from AcolyteOfPain, then played the Bloodfen Raptor
-		assertEquals(resBoard.getNumMinions_p0(), 3);
-		assertEquals(resBoard.getNumMinions_p1(), 1); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 1); //1 card drawn from AcolyteOfPain, then played the Bloodfen Raptor
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 1); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 1); //2 mana used... it's better to put down a Bloodfen Raptor than an Acolyte of Pain
 		assertEquals(resBoard.getMana_p1(), 3);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 30);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 30);
 	}
 	
 	@Test
@@ -175,22 +175,22 @@ public class TestAcolyteOfPain {
 		board.data_.setMaxMana_p0((byte)3);
 		board.data_.setMaxMana_p1((byte)3);
 
-		board.data_.removeMinion(1, 0);
-		board.data_.removeMinion(1, 0);
-		board.data_.placeMinion(1, new AcolyteOfPain());
+		board.data_.removeMinion(board.data_.getWaitingPlayer(), 0);
+		board.data_.removeMinion(board.data_.getWaitingPlayer(), 0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), new AcolyteOfPain());
 		
-		assertEquals(board.data_.getNumCards_hand_p1(), 0);
+		assertEquals(board.data_.getNumCardsHandWaitingPlayer(), 0);
 
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 1); //1 card drawn from AcolyteOfPain, then played the Bloodfen Raptor
-		assertEquals(resBoard.getNumCards_hand_p1(), 1); //1 card drawn from AcolyteOfPain.  The Acolytes smack into each other.
-		assertEquals(resBoard.getNumMinions_p0(), 3);
-		assertEquals(resBoard.getNumMinions_p1(), 1); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 1); //1 card drawn from AcolyteOfPain, then played the Bloodfen Raptor
+		assertEquals(resBoard.getNumCardsHandWaitingPlayer(), 1); //1 card drawn from AcolyteOfPain.  The Acolytes smack into each other.
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 1); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 1); //2 mana used... it's better to put down a Bloodfen Raptor than an Acolyte of Pain
 		assertEquals(resBoard.getMana_p1(), 3);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 29);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 29);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestAmaniBerserker.java
+++ b/src/test/java/com/hearthsim/test/minion/TestAmaniBerserker.java
@@ -36,12 +36,12 @@ public class TestAmaniBerserker {
 		Minion minion1_1 = new RaidLeader();
 		Minion minion1_2 = new ArgentSquire();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -51,7 +51,7 @@ public class TestAmaniBerserker {
 		deck = new Deck(cards);
 
 		Card fb = new AmaniBerserker();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -61,17 +61,17 @@ public class TestAmaniBerserker {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -87,31 +87,31 @@ public class TestAmaniBerserker {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 	
 
@@ -120,120 +120,120 @@ public class TestAmaniBerserker {
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 		
 		
-		target = board.data_.getCharacter(1, 0);
-		Minion ab = board.data_.getMinion_p0(2);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion ab = board.data_.getCurrentPlayer().getMinions().get(2);
 		ab.hasAttacked(false);
-		ret = ab.attack(1, target, board, deck, null);
+		ret = ab.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 27);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 		
-		target = board.data_.getCharacter(1, 1);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
 		ab.hasAttacked(false);
-		ret = ab.attack(1, target, board, deck, null);
+		ret = ab.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 27);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3 + 3); //enraged!
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3 + 3); //enraged!
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertFalse(board.data_.getMinion_p1(0).getDivineShield());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 
 		
 		
-		board.data_.placeCard_hand_p0(new HolyLight());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 3);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new HolyLight());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 27);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 27);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3); //not enraged anymore!
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3); //not enraged anymore!
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertFalse(board.data_.getMinion_p1(0).getDivineShield());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestAncientOfLore.java
+++ b/src/test/java/com/hearthsim/test/minion/TestAncientOfLore.java
@@ -31,11 +31,11 @@ public class TestAncientOfLore {
 		Minion minion1_0 = new BloodfenRaptor();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -52,16 +52,16 @@ public class TestAncientOfLore {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -70,39 +70,39 @@ public class TestAncientOfLore {
 		board.data_.resetMinions();
 		
 		Minion fb = new AncientOfLore();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
 	@Test
 	public void test1() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
 		
 		//first child should be a CardDrawNode

--- a/src/test/java/com/hearthsim/test/minion/TestArcaneGolem.java
+++ b/src/test/java/com/hearthsim/test/minion/TestArcaneGolem.java
@@ -32,11 +32,11 @@ public class TestArcaneGolem {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestArcaneGolem {
 		deck = new Deck(cards);
 
 		Card fb = new ArcaneGolem();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -56,16 +56,16 @@ public class TestArcaneGolem {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -81,83 +81,83 @@ public class TestArcaneGolem {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 9);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		
 		//----------------------------------------------------------
 		
-		Minion minion = board.data_.getMinion_p0(2);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(2);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 9);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7 - 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7 - 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 	}
@@ -176,18 +176,18 @@ public class TestArcaneGolem {
 		board.data_.setMaxMana_p0((byte)3);
 		board.data_.setMaxMana_p1((byte)3);
 
-		board.data_.getCharacter(0, 1).hasAttacked(true);
-		board.data_.getCharacter(0, 2).hasAttacked(true);
+		board.data_.getCharacter(board.data_.getCurrentPlayer(), 1).hasAttacked(true);
+		board.data_.getCharacter(board.data_.getCurrentPlayer(), 2).hasAttacked(true);
 
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 0);
-		assertEquals(resBoard.getNumMinions_p0(), 3);
-		assertEquals(resBoard.getNumMinions_p1(), 2); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 0);
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 2); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 0); //3 mana used
 		assertEquals(resBoard.getMana_p1(), 4); //1 mana given by the Arcane Golem
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 25); //5 damage to the face... 4 from Arcane Golem (he has charge!), 1 more from Raid Leader's buff
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 25); //5 damage to the face... 4 from Arcane Golem (he has charge!), 1 more from Raid Leader's buff
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestArchmage.java
+++ b/src/test/java/com/hearthsim/test/minion/TestArchmage.java
@@ -32,11 +32,11 @@ public class TestArchmage {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,10 +46,10 @@ public class TestArchmage {
 		deck = new Deck(cards);
 
 		Card am = new Archmage();
-		board.data_.placeCard_hand_p0(am);
+		board.data_.placeCardHandCurrentPlayer(am);
 
 		Card hs = new HolySmite();
-		board.data_.placeCard_hand_p0(hs);
+		board.data_.placeCardHandCurrentPlayer(hs);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -104,127 +104,127 @@ public class TestArchmage {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 2);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);		
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
-		assertEquals(attack0, board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(attack0, board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(attack0, board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 		
-		assertEquals(1, board.data_.getSpellDamage(0));
+		assertEquals(1, board.data_.getSpellDamage(board.data_.getCurrentPlayer()));
 		
-		target = board.data_.getCharacter(1, 0);
-		theCard = board.data_.getCard_hand_p0(0);
-		ret = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(30, board.data_.getHero_p0().getHealth());
-		assertEquals(27, board.data_.getHero_p1().getHealth());
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(30, board.data_.getCurrentPlayerHero().getHealth());
+		assertEquals(27, board.data_.getWaitingPlayerHero().getHealth());
 		assertEquals(board.data_.getMana_p0(), 1);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
-		assertEquals(attack0, board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(attack0, board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(attack0, board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);		
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
-		assertEquals(attack0, board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(attack0, board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(attack0, board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 		
-		assertEquals(1, board.data_.getSpellDamage(0));
+		assertEquals(1, board.data_.getSpellDamage(board.data_.getCurrentPlayer()));
 		
-		target = board.data_.getCharacter(1, 1);
-		theCard = board.data_.getCard_hand_p0(0);
-		ret = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(3, board.data_.getNumMinions_p0());
-		assertEquals(1, board.data_.getNumMinions_p1());
-		assertEquals(30, board.data_.getHero_p0().getHealth());
-		assertEquals(30, board.data_.getHero_p1().getHealth());
+		assertEquals(3, board.data_.getCurrentPlayer().getNumMinions());
+		assertEquals(1, board.data_.getWaitingPlayer().getNumMinions());
+		assertEquals(30, board.data_.getCurrentPlayerHero().getHealth());
+		assertEquals(30, board.data_.getWaitingPlayerHero().getHealth());
 		assertEquals(board.data_.getMana_p0(), 1);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health1 - 1);
 		
-		assertEquals(attack0, board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p0(1).getTotalAttack(), attack0);
-		assertEquals(attack0, board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(attack0, board.data_.getMinion_p1(0).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
+		assertEquals(attack0, board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(attack0, board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
 	}
 
 }

--- a/src/test/java/com/hearthsim/test/minion/TestArchmageAntonidas.java
+++ b/src/test/java/com/hearthsim/test/minion/TestArchmageAntonidas.java
@@ -31,11 +31,11 @@ public class TestArchmageAntonidas {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestArchmageAntonidas {
 		deck = new Deck(cards);
 
 		Card fb = new ArchmageAntonidas();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -55,16 +55,16 @@ public class TestArchmageAntonidas {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -80,108 +80,108 @@ public class TestArchmageAntonidas {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 1);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		
 		//----------------------------------------------------------
 		// Use a spell now... p0 should get a Fireball
 		Card cardToUse = new HolySmite();
-		board.data_.placeCard_hand_p0(cardToUse);
-		target = board.data_.getCharacter(1, 1);
-		ret = cardToUse.useOn(1, target, ret, deck, null);
+		board.data_.placeCardHandCurrentPlayer(cardToUse);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = cardToUse.useOn(ret.data_.getWaitingPlayer(), target, ret, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 0);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
 		
 		//----------------------------------------------------------
 		// flipped, p1 should not get a Fireball
 		HearthTreeNode flp = new HearthTreeNode(board.data_.flipPlayers());
 		Card cardToUse2 = new HolySmite();
-		flp.data_.placeCard_hand_p0(cardToUse2);
+		flp.data_.placeCardHandCurrentPlayer(cardToUse2);
 
 		assertEquals(ret.data_.getNumCards_hand(), 1);
 
-		target = flp.data_.getCharacter(1, 1);
-		ret = cardToUse2.useOn(1, target, flp, deck, null);
+		target = flp.data_.getCharacter(flp.data_.getWaitingPlayer(), 1);
+		ret = cardToUse2.useOn(flp.data_.getWaitingPlayer(), target, flp, deck, null);
 
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 1);
-		assertEquals(ret.data_.getNumMinions_p1(), 2);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(ret.data_.getMana_p0(), 7);
 		assertEquals(ret.data_.getMana_p1(), 0);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
-		assertEquals(ret.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(ret.data_.getMinion_p1(0).getHealth(), 7);
-		assertEquals(ret.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 6);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalAttack(), 5);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
 		
 	}
 

--- a/src/test/java/com/hearthsim/test/minion/TestArmorsmith.java
+++ b/src/test/java/com/hearthsim/test/minion/TestArmorsmith.java
@@ -32,11 +32,11 @@ public class TestArmorsmith {
 		Minion minion1_0 = new BloodfenRaptor();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -53,16 +53,16 @@ public class TestArmorsmith {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -71,7 +71,7 @@ public class TestArmorsmith {
 		board.data_.resetMinions();
 		
 		Minion fb = new Armorsmith();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
@@ -79,130 +79,130 @@ public class TestArmorsmith {
 	@Test
 	public void test0() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
 		
 		
 		
 		
-		board.data_.placeCard_hand_p0(new HolySmite());
-		theCard = board.data_.getCard_hand_p0(0);
+		board.data_.placeCardHandCurrentPlayer(new HolySmite());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
 		
-		target = board.data_.getCharacter(0, 3);
-		ret = theCard.useOn(0, target, ret, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, ret, deck, null);
 		assertFalse(ret == null);
 
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 3);
-		assertEquals(ret.data_.getNumMinions_p1(), 2);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p0().getArmor(), 1);
-		assertEquals(ret.data_.getHero_p1().getArmor(), 0);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getCurrentPlayerHero().getArmor(), 1);
+		assertEquals(ret.data_.getWaitingPlayerHero().getArmor(), 0);
 
-		assertEquals(ret.data_.getMinion_p0(0).getTotalHealth(), 5);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalHealth(), 4);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalHealth(), 2);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 5);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 4);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 2);
 		
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(ret.data_.getMinion_p0(0).getAuraAttack(), 2);
-		assertEquals(ret.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(ret.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(ret.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(ret.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 2);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
 		
 		
 		
-		board.data_.placeCard_hand_p0(new HolySmite());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(1, 2);
-		ret = theCard.useOn(1, target, ret, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new HolySmite());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = theCard.useOn(ret.data_.getWaitingPlayer(), target, ret, deck, null);
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 3);
-		assertEquals(ret.data_.getNumMinions_p1(), 1);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p0().getArmor(), 1);
-		assertEquals(ret.data_.getHero_p1().getArmor(), 0);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 1);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getCurrentPlayerHero().getArmor(), 1);
+		assertEquals(ret.data_.getWaitingPlayerHero().getArmor(), 0);
 
-		assertEquals(ret.data_.getMinion_p0(0).getTotalHealth(), 5);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalHealth(), 4);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalHealth(), 2);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 5);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 4);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
 		
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 2);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
 		
-		assertEquals(ret.data_.getMinion_p0(0).getAuraAttack(), 2);
-		assertEquals(ret.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(ret.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(ret.data_.getMinion_p1(0).getAuraAttack(), 0);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 2);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
 		
 		
 		ret = new HearthTreeNode(ret.data_.flipPlayers());
-		ret.data_.placeCard_hand_p0(new HolySmite());
-		theCard = ret.data_.getCard_hand_p0(0);
-		target = ret.data_.getCharacter(1, 2);
-		ret = theCard.useOn(1, target, ret, deck, null);
+		ret.data_.placeCardHandCurrentPlayer(new HolySmite());
+		theCard = ret.data_.getCurrentPlayerCardHand(0);
+		target = ret.data_.getCharacter(ret.data_.getWaitingPlayer(), 2);
+		ret = theCard.useOn(ret.data_.getWaitingPlayer(), target, ret, deck, null);
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p1(), 3);
-		assertEquals(ret.data_.getNumMinions_p0(), 1);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getArmor(), 2);
-		assertEquals(ret.data_.getHero_p0().getArmor(), 0);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getArmor(), 2);
+		assertEquals(ret.data_.getCurrentPlayerHero().getArmor(), 0);
 
-		assertEquals(ret.data_.getMinion_p1(0).getTotalHealth(), 5);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalHealth(), 1);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalHealth(), 4);
-		assertEquals(ret.data_.getMinion_p0(0).getTotalHealth(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 5);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
 		
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalAttack(), 7);
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
 		
-		assertEquals(ret.data_.getMinion_p1(0).getAuraAttack(), 2);
-		assertEquals(ret.data_.getMinion_p1(1).getAuraAttack(), 1);
-		assertEquals(ret.data_.getMinion_p1(2).getAuraAttack(), 1);
-		assertEquals(ret.data_.getMinion_p0(0).getAuraAttack(), 0);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 0);
 	}
 	
 }

--- a/src/test/java/com/hearthsim/test/minion/TestBigGameHunter.java
+++ b/src/test/java/com/hearthsim/test/minion/TestBigGameHunter.java
@@ -31,14 +31,14 @@ public class TestBigGameHunter {
 		Minion minion1_2 = new Abomination();
 		Minion minion1_3 = new LootHoarder();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
-		board.data_.placeCard_hand_p0(minion0_2);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_2);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
-		board.data_.placeCard_hand_p1(minion1_3);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_3);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -55,19 +55,19 @@ public class TestBigGameHunter {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -76,7 +76,7 @@ public class TestBigGameHunter {
 		board.data_.resetMinions();
 		
 		Minion fb = new BigGameHunter();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
@@ -86,134 +86,134 @@ public class TestBigGameHunter {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, deck);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
 		
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {	
 		
 		//set the remaining total health of Abomination to 1
-		board.data_.getMinion_p1(1).setHealth((byte)1);
+		board.data_.getWaitingPlayer().getMinions().get(1).setHealth((byte)1);
 		
 		//And the Abomination was somehow buffed to 8 attack
-		board.data_.getMinion_p1(1).setAttack((byte)8);
+		board.data_.getWaitingPlayer().getMinions().get(1).setAttack((byte)8);
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, deck);
 		
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 4);
-		assertEquals(ret.data_.getNumMinions_p1(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(ret.data_.getMana_p0(), 6);
 		assertEquals(ret.data_.getMana_p1(), 10);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(ret.data_.getMinion_p0(0).getTotalHealth(), 3);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalHealth(), 4);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalHealth(), 3);
-		assertEquals(ret.data_.getMinion_p0(3).getTotalHealth(), 6);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 6);
 		
-		assertEquals(ret.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalHealth(), 1);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(ret.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p0(3).getTotalAttack(), 7);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
 		
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalAttack(), 9);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(ret.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 9);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 		
 		//3 children nodes: Kill the Stormwind Champion, Boulderfist Ogre, and Abomination
 		assertEquals(ret.numChildren(), 3);
 		
 		//First child node is the one that kills the Stormwind Champion
 		HearthTreeNode cn3 = ret.getChildren().get(0);
-		assertEquals(cn3.data_.getNumCards_hand_p0(), 0);
-		assertEquals(cn3.data_.getNumCards_hand_p1(), 0);
-		assertEquals(cn3.data_.getNumMinions_p0(), 3);
-		assertEquals(cn3.data_.getNumMinions_p1(), 4);
+		assertEquals(cn3.data_.getNumCardsHandCurrentPlayer(), 0);
+		assertEquals(cn3.data_.getNumCardsHandWaitingPlayer(), 0);
+		assertEquals(cn3.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(cn3.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(cn3.data_.getMana_p0(), 6);
 		assertEquals(cn3.data_.getMana_p1(), 10);
-		assertEquals(cn3.data_.getHero_p0().getHealth(), 30);
-		assertEquals(cn3.data_.getHero_p1().getHealth(), 30);
+		assertEquals(cn3.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(cn3.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(cn3.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(cn3.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(cn3.data_.getMinion_p0(2).getTotalHealth(), 2);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 2);
 
-		assertEquals(cn3.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(cn3.data_.getMinion_p1(1).getTotalHealth(), 1);
-		assertEquals(cn3.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(ret.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(cn3.data_.getMinion_p0(0).getTotalAttack(), 5);
-		assertEquals(cn3.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(cn3.data_.getMinion_p0(2).getTotalAttack(), 2);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 5);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 2);
 		
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(cn3.data_.getMinion_p1(1).getTotalAttack(), 9);
-		assertEquals(cn3.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(cn3.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 9);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 	
 		//Second child node is the one that kills the Abomination
 		HearthTreeNode cn4 = ret.getChildren().get(1);
-		assertEquals(cn4.data_.getNumCards_hand_p0(), 0);
-		assertEquals(cn4.data_.getNumCards_hand_p1(), 1);
-		assertEquals(cn4.data_.getNumMinions_p0(), 4);
-		assertEquals(cn4.data_.getNumMinions_p1(), 1);
+		assertEquals(cn4.data_.getNumCardsHandCurrentPlayer(), 0);
+		assertEquals(cn4.data_.getNumCardsHandWaitingPlayer(), 1);
+		assertEquals(cn4.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(cn4.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(cn4.data_.getMana_p0(), 6);
 		assertEquals(cn4.data_.getMana_p1(), 10);
-		assertEquals(cn4.data_.getHero_p0().getHealth(), 28);
-		assertEquals(cn4.data_.getHero_p1().getHealth(), 28);
+		assertEquals(cn4.data_.getCurrentPlayerHero().getHealth(), 28);
+		assertEquals(cn4.data_.getWaitingPlayerHero().getHealth(), 28);
 		
-		assertEquals(cn4.data_.getMinion_p0(0).getTotalHealth(), 1);
-		assertEquals(cn4.data_.getMinion_p0(1).getTotalHealth(), 2);
-		assertEquals(cn4.data_.getMinion_p0(2).getTotalHealth(), 1);
-		assertEquals(cn4.data_.getMinion_p0(3).getTotalHealth(), 4);
-		assertEquals(cn4.data_.getMinion_p1(0).getTotalHealth(), 5);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 2);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 1);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 4);
+		assertEquals(cn4.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 5);
 
-		assertEquals(cn4.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(cn4.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(cn4.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(cn4.data_.getMinion_p0(3).getTotalAttack(), 7);
-		assertEquals(cn4.data_.getMinion_p1(0).getTotalAttack(), 6);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
+		assertEquals(cn4.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestBloodfenRaptor.java
+++ b/src/test/java/com/hearthsim/test/minion/TestBloodfenRaptor.java
@@ -29,11 +29,11 @@ public class TestBloodfenRaptor {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, health1, attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 				
 	}
 	
@@ -82,194 +82,194 @@ public class TestBloodfenRaptor {
 	@Test
 	public void test1() throws HSException {
 		BloodfenRaptor fb = new BloodfenRaptor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test1_0", ret == null);
 		assertTrue("test1_1", board.data_.getNumCards_hand() == 1);
-		assertTrue("test1_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test1_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test1_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test1_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test1_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test1_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test1_8", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test1_9", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test1_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test1_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test1_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test1_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test1_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test1_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test1_8", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test1_9", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		BloodfenRaptor fb = new BloodfenRaptor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertFalse("test2_0", ret == null);
 		assertTrue("test2_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test2_2", board.data_.getNumMinions_p0() == 3);
-		assertTrue("test2_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test2_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test2_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test2_6", board.data_.getMinion_p0(0).getHealth() == fb.getHealth());
-		assertTrue("test2_7", board.data_.getMinion_p0(1).getHealth() == health0);
-		assertTrue("test2_8", board.data_.getMinion_p0(2).getHealth() == health1);
-		assertTrue("test2_9", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test2_10", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test2_2", board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue("test2_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test2_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test2_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test2_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == fb.getHealth());
+		assertTrue("test2_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue("test2_8", board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == health1);
+		assertTrue("test2_9", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test2_10", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 		
-		Minion theAttacker = board.data_.getMinion_p0(0);
-		target = board.data_.getCharacter(0, 0);
-		ret = theAttacker.useOn(0, target, board, null, null);
+		Minion theAttacker = board.data_.getCurrentPlayer().getMinions().get(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		ret = theAttacker.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		assertTrue("test2", ret == null);
 
-		target = board.data_.getCharacter(1, 0);
-		theAttacker = board.data_.getMinion_p0(0);
-		ret = theAttacker.useOn(1, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		theAttacker = board.data_.getCurrentPlayer().getMinions().get(0);
+		ret = theAttacker.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		assertTrue("test2", ret == null);
 
-		theAttacker = board.data_.getMinion_p0(0);
+		theAttacker = board.data_.getCurrentPlayer().getMinions().get(0);
 		theAttacker.hasAttacked(false);
 		theAttacker.hasBeenUsed(false);
-		target = board.data_.getCharacter(1, 0);
-		ret = theAttacker.attack(1, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		ret = theAttacker.attack(board.data_.getWaitingPlayer(), target, board, null, null);
 		assertFalse("test2_0", ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertTrue("test2_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test2_5", board.data_.getHero_p1().getHealth() == 27);
-		assertTrue("test2_6", board.data_.getMinion_p0(0).getHealth() == fb.getHealth());
-		assertTrue("test2_7", board.data_.getMinion_p0(1).getHealth() == health0);
-		assertTrue("test2_8", board.data_.getMinion_p0(2).getHealth() == health1);
-		assertTrue("test2_9", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test2_10", board.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue("test2", board.data_.getMinion_p0(0).hasAttacked());
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertTrue("test2_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test2_5", board.data_.getWaitingPlayerHero().getHealth() == 27);
+		assertTrue("test2_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == fb.getHealth());
+		assertTrue("test2_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue("test2_8", board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == health1);
+		assertTrue("test2_9", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test2_10", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test2", board.data_.getCurrentPlayer().getMinions().get(0).hasAttacked());
 		
-		theAttacker = board.data_.getMinion_p0(0);
+		theAttacker = board.data_.getCurrentPlayer().getMinions().get(0);
 		theAttacker.hasAttacked(false);
 		theAttacker.hasBeenUsed(false);
-		target = board.data_.getCharacter(1, 1);
-		ret = theAttacker.attack(1, target, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = theAttacker.attack(board.data_.getWaitingPlayer(), target, board, null, null);
 		assertFalse("test2_0", ret == null);
 		assertTrue("test2_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test2_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test2_3", board.data_.getNumMinions_p1() == 1);
-		assertTrue("test2_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test2_5", board.data_.getHero_p1().getHealth() == 27);
-		assertTrue("test2_7", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test2_8", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test2_9", board.data_.getMinion_p1(0).getHealth() == health1);
+		assertTrue("test2_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test2_3", board.data_.getWaitingPlayer().getNumMinions() == 1);
+		assertTrue("test2_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test2_5", board.data_.getWaitingPlayerHero().getHealth() == 27);
+		assertTrue("test2_7", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test2_8", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test2_9", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health1);
 		
 	}
 
 	@Test
 	public void test3() throws HSException {
 		BloodfenRaptor fb = new BloodfenRaptor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertFalse("test3_0", ret == null);
 		assertTrue("test3_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test3_2", board.data_.getNumMinions_p0() == 3);
-		assertTrue("test3_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test3_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test3_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test3_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test3_7", board.data_.getMinion_p0(1).getHealth() == fb.getHealth());
-		assertTrue("test3_8", board.data_.getMinion_p0(2).getHealth() == health1);
-		assertTrue("test3_9", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test3_10", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test3_2", board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue("test3_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test3_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test3_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test3_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test3_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == fb.getHealth());
+		assertTrue("test3_8", board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == health1);
+		assertTrue("test3_9", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test3_10", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 
 	@Test
 	public void test4() throws HSException {
 		BloodfenRaptor fb = new BloodfenRaptor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, null, null);
 		
 		assertFalse("test4_0", ret == null);
 		assertTrue("test4_1", board.data_.getNumCards_hand() == 0);
-		assertTrue("test4_2", board.data_.getNumMinions_p0() == 3);
-		assertTrue("test4_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test4_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test4_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test4_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test4_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test4_8", board.data_.getMinion_p0(2).getHealth() == fb.getHealth());
-		assertTrue("test4_9", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test4_10", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test4_2", board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue("test4_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test4_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test4_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test4_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test4_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test4_8", board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == fb.getHealth());
+		assertTrue("test4_9", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test4_10", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 
 	@Test
 	public void test5() throws HSException {
 		BloodfenRaptor fb = new BloodfenRaptor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test5_0", ret == null);
 		assertTrue("test5_1", board.data_.getNumCards_hand() == 1);
-		assertTrue("test5_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test5_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test5_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test5_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test5_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test5_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test5_9", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test5_10", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test5_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test5_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test5_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test5_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test5_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test5_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test5_9", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test5_10", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 
 	@Test
 	public void test6() throws HSException {
 		BloodfenRaptor fb = new BloodfenRaptor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test6_0", ret == null);
 		assertTrue("test6_1", board.data_.getNumCards_hand() == 1);
-		assertTrue("test6_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test6_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test6_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test6_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test6_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test6_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test6_9", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test6_10", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test6_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test6_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test6_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test6_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test6_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test6_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test6_9", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test6_10", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 
 	@Test
 	public void test7() throws HSException {
 		BloodfenRaptor fb = new BloodfenRaptor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(1, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, null, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, null, null);
 		
 		assertTrue("test7_0", ret == null);
 		assertTrue("test7_1", board.data_.getNumCards_hand() == 1);
-		assertTrue("test7_2", board.data_.getNumMinions_p0() == 2);
-		assertTrue("test7_3", board.data_.getNumMinions_p1() == 2);
-		assertTrue("test7_4", board.data_.getHero_p0().getHealth() == 30);
-		assertTrue("test7_5", board.data_.getHero_p1().getHealth() == 30);
-		assertTrue("test7_6", board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue("test7_7", board.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue("test7_9", board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue("test7_10", board.data_.getMinion_p1(1).getHealth() == health1);
+		assertTrue("test7_2", board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue("test7_3", board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue("test7_4", board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue("test7_5", board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue("test7_6", board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test7_7", board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue("test7_9", board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue("test7_10", board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestCairneBloodhoof.java
+++ b/src/test/java/com/hearthsim/test/minion/TestCairneBloodhoof.java
@@ -29,11 +29,11 @@ public class TestCairneBloodhoof {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -43,7 +43,7 @@ public class TestCairneBloodhoof {
 		deck = new Deck(cards);
 
 		Card fb = new CairneBloodhoof();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -53,16 +53,16 @@ public class TestCairneBloodhoof {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -78,88 +78,88 @@ public class TestCairneBloodhoof {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		
 		//----------------------------------------------------------
 		
-		Minion minion = board.data_.getMinion_p0(2);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(2);
 		assertTrue(minion instanceof CairneBloodhoof);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7 - 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7 - 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p0(2) instanceof BaineBloodhoof);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2) instanceof BaineBloodhoof);
 		
 	}
 
@@ -168,61 +168,61 @@ public class TestCairneBloodhoof {
 	public void test3() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		
 		//----------------------------------------------------------
 		
-		Minion minion = board.data_.getMinion_p0(1);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(1);
 		assertTrue(minion instanceof CairneBloodhoof);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7 - 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7 - 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p0(1) instanceof BaineBloodhoof);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1) instanceof BaineBloodhoof);
 		
 	}
 
@@ -230,60 +230,60 @@ public class TestCairneBloodhoof {
 	public void test4() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		//----------------------------------------------------------
 		HearthTreeNode fb = new HearthTreeNode(board.data_.flipPlayers());
 		
-		Minion minion = fb.data_.getMinion_p0(1);
+		Minion minion = fb.data_.getCurrentPlayer().getMinions().get(1);
 		
 		minion.hasAttacked(false);
-		target = fb.data_.getCharacter(1, 2);
-		minion.attack(1, target, fb, deck, null);
+		target = fb.data_.getCharacter(fb.data_.getWaitingPlayer(), 2);
+		minion.attack(fb.data_.getWaitingPlayer(), target, fb, deck, null);
 
 		assertEquals(fb.data_.getNumCards_hand(), 0);
-		assertEquals(fb.data_.getNumMinions_p0(), 2);
-		assertEquals(fb.data_.getNumMinions_p1(), 3);
+		assertEquals(fb.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(fb.data_.getMana_p0(), 8);
 		assertEquals(fb.data_.getMana_p1(), 2);
-		assertEquals(fb.data_.getHero_p0().getHealth(), 30);
-		assertEquals(fb.data_.getHero_p1().getHealth(), 30);
-		assertEquals(fb.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p0(1).getHealth(), 7 - 5);
-		assertEquals(fb.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p1(1).getHealth(), 5);
-		assertEquals(fb.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(fb.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(fb.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7 - 5);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(fb.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(fb.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(fb.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(fb.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(fb.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(fb.data_.getMinion_p1(1) instanceof BaineBloodhoof);
+		assertTrue(fb.data_.getWaitingPlayer().getMinions().get(1) instanceof BaineBloodhoof);
 		
 	}
 	
@@ -291,81 +291,81 @@ public class TestCairneBloodhoof {
 	public void test5() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 
-		ret = new BloodfenRaptor().summonMinion(0, board.data_.getHero_p0(), ret, null, null, false);
-		ret = new BloodfenRaptor().summonMinion(0, board.data_.getHero_p0(), ret, null, null, false);
-		ret = new BloodfenRaptor().summonMinion(0, board.data_.getHero_p0(), ret, null, null, false);
-		ret = new BloodfenRaptor().summonMinion(0, board.data_.getHero_p0(), ret, null, null, false);
+		ret = new BloodfenRaptor().summonMinion(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), ret, null, null, false);
+		ret = new BloodfenRaptor().summonMinion(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), ret, null, null, false);
+		ret = new BloodfenRaptor().summonMinion(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), ret, null, null, false);
+		ret = new BloodfenRaptor().summonMinion(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), ret, null, null, false);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 7);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(3).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(4).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(5).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(6).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(4).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(5).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(6).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(4).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(5).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p0(6).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(4).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(5).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(6).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		//----------------------------------------------------------
 		HearthTreeNode fb = new HearthTreeNode(board.data_.flipPlayers());
 		
-		Minion minion = fb.data_.getMinion_p0(1);
+		Minion minion = fb.data_.getCurrentPlayer().getMinions().get(1);
 		
 		minion.hasAttacked(false);
-		target = fb.data_.getCharacter(1, 6);
-		minion.attack(1, target, fb, deck, null);
+		target = fb.data_.getCharacter(fb.data_.getWaitingPlayer(), 6);
+		minion.attack(fb.data_.getWaitingPlayer(), target, fb, deck, null);
 
 		assertEquals(fb.data_.getNumCards_hand(), 0);
-		assertEquals(fb.data_.getNumMinions_p0(), 2);
-		assertEquals(fb.data_.getNumMinions_p1(), 7);
+		assertEquals(fb.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getNumMinions(), 7);
 		assertEquals(fb.data_.getMana_p0(), 8);
 		assertEquals(fb.data_.getMana_p1(), 2);
-		assertEquals(fb.data_.getHero_p0().getHealth(), 30);
-		assertEquals(fb.data_.getHero_p1().getHealth(), 30);
-		assertEquals(fb.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p0(1).getHealth(), 7 - 5);
-		assertEquals(fb.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p1(2).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p1(3).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p1(4).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p1(5).getHealth(), 5);
-		assertEquals(fb.data_.getMinion_p1(6).getHealth(), 7);
+		assertEquals(fb.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(fb.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7 - 5);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(3).getHealth(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(4).getHealth(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(5).getHealth(), 5);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(6).getHealth(), 7);
 
-		assertEquals(fb.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(fb.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(fb.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(fb.data_.getMinion_p1(1).getTotalAttack(), 4);
-		assertEquals(fb.data_.getMinion_p1(2).getTotalAttack(), 4);
-		assertEquals(fb.data_.getMinion_p1(3).getTotalAttack(), 4);
-		assertEquals(fb.data_.getMinion_p1(4).getTotalAttack(), 2);
-		assertEquals(fb.data_.getMinion_p1(5).getTotalAttack(), 5);
-		assertEquals(fb.data_.getMinion_p1(6).getTotalAttack(), 7);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 4);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(4).getTotalAttack(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(5).getTotalAttack(), 5);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(6).getTotalAttack(), 7);
 		
-		assertTrue(fb.data_.getMinion_p1(5) instanceof BaineBloodhoof);
+		assertTrue(fb.data_.getWaitingPlayer().getMinions().get(5) instanceof BaineBloodhoof);
 		
 	}
 	
@@ -376,63 +376,63 @@ public class TestCairneBloodhoof {
 		//In this test Cairne will be killed by a spell: Fireball
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		//----------------------------------------------------------
 		HearthTreeNode fb = new HearthTreeNode(board.data_.flipPlayers());
 		
-		Minion minion = fb.data_.getMinion_p0(1);
+		Minion minion = fb.data_.getCurrentPlayer().getMinions().get(1);
 		
-		fb.data_.placeCard_hand_p0(new Fireball());
-		Card fireball = fb.data_.getCard_hand_p0(0);
+		fb.data_.placeCardHandCurrentPlayer(new Fireball());
+		Card fireball = fb.data_.getCurrentPlayerCardHand(0);
 		
 		minion.hasAttacked(false);
-		target = fb.data_.getCharacter(1, 2);
-		fireball.useOn(1, target, fb, deck, null);
+		target = fb.data_.getCharacter(fb.data_.getWaitingPlayer(), 2);
+		fireball.useOn(fb.data_.getWaitingPlayer(), target, fb, deck, null);
 
 		assertEquals(fb.data_.getNumCards_hand(), 0);
-		assertEquals(fb.data_.getNumMinions_p0(), 2);
-		assertEquals(fb.data_.getNumMinions_p1(), 3);
+		assertEquals(fb.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(fb.data_.getMana_p0(), 4);
 		assertEquals(fb.data_.getMana_p1(), 2);
-		assertEquals(fb.data_.getHero_p0().getHealth(), 30);
-		assertEquals(fb.data_.getHero_p1().getHealth(), 30);
-		assertEquals(fb.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(fb.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(fb.data_.getMinion_p1(1).getHealth(), 5);
-		assertEquals(fb.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(fb.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(fb.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(fb.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(fb.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(fb.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(fb.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(fb.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(fb.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(fb.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(fb.data_.getMinion_p1(1) instanceof BaineBloodhoof);
+		assertTrue(fb.data_.getWaitingPlayer().getMinions().get(1) instanceof BaineBloodhoof);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestColdlightOracle.java
+++ b/src/test/java/com/hearthsim/test/minion/TestColdlightOracle.java
@@ -33,11 +33,11 @@ public class TestColdlightOracle {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,7 +47,7 @@ public class TestColdlightOracle {
 		deck = new Deck(cards);
 
 		Card fb = new ColdlightOracle();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -57,16 +57,16 @@ public class TestColdlightOracle {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -82,60 +82,60 @@ public class TestColdlightOracle {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, deck);
 		
 		assertFalse(ret == null);
-		assertEquals(board.data_.getNumCards_hand_p0(), 0);
+		assertEquals(board.data_.getNumCardsHandCurrentPlayer(), 0);
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals(((CardDrawNode)ret).getNumCardsToDraw(), 2);
 		
-		assertEquals(board.data_.getNumCards_hand_p1(), 2);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getNumCardsHandWaitingPlayer(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 	}
@@ -155,20 +155,20 @@ public class TestColdlightOracle {
 		board.data_.setMaxMana_p0((byte)3);
 		board.data_.setMaxMana_p1((byte)3);
 
-		board.data_.getCharacter(0, 1).hasAttacked(true);
-		board.data_.getCharacter(0, 2).hasAttacked(true);
+		board.data_.getCharacter(board.data_.getCurrentPlayer(), 1).hasAttacked(true);
+		board.data_.getCharacter(board.data_.getCurrentPlayer(), 2).hasAttacked(true);
 
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 2); //1 card drawn from Loot Horder attacking and dying, no mana left to play the card
-		assertEquals(resBoard.getNumMinions_p0(), 3);
-		assertEquals(resBoard.getNumMinions_p1(), 2); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 2); //1 card drawn from Loot Horder attacking and dying, no mana left to play the card
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 2); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 0);
 		assertEquals(resBoard.getMana_p1(), 3);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 30);
-		assertEquals(resBoard.getNumCards_hand_p0(), 2);
-		assertEquals(resBoard.getNumCards_hand_p1(), 2);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 2);
+		assertEquals(resBoard.getNumCardsHandWaitingPlayer(), 2);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestCrazedAlchemist.java
+++ b/src/test/java/com/hearthsim/test/minion/TestCrazedAlchemist.java
@@ -31,14 +31,14 @@ public class TestCrazedAlchemist {
 		Minion minion1_2 = new Abomination();
 		Minion minion1_3 = new LootHoarder();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
-		board.data_.placeCard_hand_p0(minion0_2);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_2);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
-		board.data_.placeCard_hand_p1(minion1_3);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_3);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -55,19 +55,19 @@ public class TestCrazedAlchemist {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -76,7 +76,7 @@ public class TestCrazedAlchemist {
 		board.data_.resetMinions();
 		
 		Minion fb = new CrazedAlchemist();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
@@ -87,34 +87,34 @@ public class TestCrazedAlchemist {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, deck);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 	}
 	
 	
@@ -123,98 +123,98 @@ public class TestCrazedAlchemist {
 	public void test1() throws HSException {	
 		
 		//set the remaining total health of Abomination to 1
-		board.data_.getMinion_p1(1).setHealth((byte)1);
+		board.data_.getWaitingPlayer().getMinions().get(1).setHealth((byte)1);
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, deck);
 		
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 4);
-		assertEquals(ret.data_.getNumMinions_p1(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(ret.data_.getMana_p0(), 8);
 		assertEquals(ret.data_.getMana_p1(), 10);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(ret.data_.getMinion_p0(0).getTotalHealth(), 3);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalHealth(), 4);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalHealth(), 3);
-		assertEquals(ret.data_.getMinion_p0(3).getTotalHealth(), 6);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalHealth(), 1);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(ret.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 6);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p0(3).getTotalAttack(), 7);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(ret.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 		
 		assertEquals(ret.numChildren(), 7);
 		
 		//Forth child node is the one that hits the Loot Hoarder
 		HearthTreeNode cn3 = ret.getChildren().get(3);
-		assertEquals(cn3.data_.getNumCards_hand_p0(), 0);
-		assertEquals(cn3.data_.getNumCards_hand_p1(), 0);
-		assertEquals(cn3.data_.getNumMinions_p0(), 4);
-		assertEquals(cn3.data_.getNumMinions_p1(), 4);
+		assertEquals(cn3.data_.getNumCardsHandCurrentPlayer(), 0);
+		assertEquals(cn3.data_.getNumCardsHandWaitingPlayer(), 0);
+		assertEquals(cn3.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(cn3.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(cn3.data_.getMana_p0(), 8);
 		assertEquals(cn3.data_.getMana_p1(), 10);
-		assertEquals(cn3.data_.getHero_p0().getHealth(), 30);
-		assertEquals(cn3.data_.getHero_p1().getHealth(), 30);
+		assertEquals(cn3.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(cn3.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(cn3.data_.getMinion_p0(0).getTotalHealth(), 3);
-		assertEquals(cn3.data_.getMinion_p0(1).getTotalHealth(), 4);
-		assertEquals(cn3.data_.getMinion_p0(2).getTotalHealth(), 3);
-		assertEquals(cn3.data_.getMinion_p0(3).getTotalHealth(), 6);
-		assertEquals(cn3.data_.getMinion_p1(0).getTotalHealth(), 3);
-		assertEquals(cn3.data_.getMinion_p1(1).getTotalHealth(), 1);
-		assertEquals(cn3.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(cn3.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 3);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 3);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 6);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 3);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(cn3.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(cn3.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(cn3.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(cn3.data_.getMinion_p0(3).getTotalAttack(), 7);
-		assertEquals(cn3.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(cn3.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(cn3.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(cn3.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 	
 		//First child node is the one that hits the Harvest Golem
 		HearthTreeNode cn2 = ret.getChildren().get(0);
-		assertEquals(cn2.data_.getNumCards_hand_p0(), 0);
-		assertEquals(cn2.data_.getNumCards_hand_p1(), 0);
-		assertEquals(cn2.data_.getNumMinions_p0(), 4);
-		assertEquals(cn2.data_.getNumMinions_p1(), 4);
+		assertEquals(cn2.data_.getNumCardsHandCurrentPlayer(), 0);
+		assertEquals(cn2.data_.getNumCardsHandWaitingPlayer(), 0);
+		assertEquals(cn2.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(cn2.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(cn2.data_.getMana_p0(), 8);
 		assertEquals(cn2.data_.getMana_p1(), 10);
-		assertEquals(cn2.data_.getHero_p0().getHealth(), 30);
-		assertEquals(cn2.data_.getHero_p1().getHealth(), 30);
+		assertEquals(cn2.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(cn2.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(cn2.data_.getMinion_p0(0).getTotalHealth(), 3);
-		assertEquals(cn2.data_.getMinion_p0(1).getTotalHealth(), 5);
-		assertEquals(cn2.data_.getMinion_p0(2).getTotalHealth(), 3);
-		assertEquals(cn2.data_.getMinion_p0(3).getTotalHealth(), 6);
-		assertEquals(cn2.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(cn2.data_.getMinion_p1(1).getTotalHealth(), 1);
-		assertEquals(cn2.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(cn2.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 3);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 5);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 3);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 6);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(cn2.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(cn2.data_.getMinion_p0(1).getTotalAttack(), 6);
-		assertEquals(cn2.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(cn2.data_.getMinion_p0(3).getTotalAttack(), 7);
-		assertEquals(cn2.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(cn2.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(cn2.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(cn2.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 6);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(cn2.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(cn2.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestCruelTaskmaster.java
+++ b/src/test/java/com/hearthsim/test/minion/TestCruelTaskmaster.java
@@ -30,14 +30,14 @@ public class TestCruelTaskmaster {
 		Minion minion1_2 = new Abomination();
 		Minion minion1_3 = new LootHoarder();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
-		board.data_.placeCard_hand_p0(minion0_2);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_2);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
-		board.data_.placeCard_hand_p1(minion1_3);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_3);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -54,19 +54,19 @@ public class TestCruelTaskmaster {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -75,7 +75,7 @@ public class TestCruelTaskmaster {
 		board.data_.resetMinions();
 		
 		Minion fb = new CruelTaskmaster();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
@@ -85,126 +85,126 @@ public class TestCruelTaskmaster {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, deck);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {	
 		
 		//set the remaining total health of Abomination to 1
-		board.data_.getMinion_p1(1).setHealth((byte)1);
+		board.data_.getWaitingPlayer().getMinions().get(1).setHealth((byte)1);
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, deck);
 		
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 4);
-		assertEquals(ret.data_.getNumMinions_p1(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(ret.data_.getMana_p0(), 8);
 		assertEquals(ret.data_.getMana_p1(), 10);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(ret.data_.getMinion_p0(0).getTotalHealth(), 3);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalHealth(), 4);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalHealth(), 3);
-		assertEquals(ret.data_.getMinion_p0(3).getTotalHealth(), 6);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalHealth(), 1);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(ret.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 6);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p0(3).getTotalAttack(), 7);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(ret.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 		
 		assertEquals(ret.numChildren(), 7);
 		
 		//Forth child node is the one that kills the Loot Hoarder
 		HearthTreeNode cn3 = ret.getChildren().get(3);
-		assertEquals(cn3.data_.getNumCards_hand_p0(), 0);
-		assertEquals(cn3.data_.getNumCards_hand_p1(), 1);
-		assertEquals(cn3.data_.getNumMinions_p0(), 4);
-		assertEquals(cn3.data_.getNumMinions_p1(), 3);
+		assertEquals(cn3.data_.getNumCardsHandCurrentPlayer(), 0);
+		assertEquals(cn3.data_.getNumCardsHandWaitingPlayer(), 1);
+		assertEquals(cn3.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(cn3.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(cn3.data_.getMana_p0(), 8);
 		assertEquals(cn3.data_.getMana_p1(), 10);
-		assertEquals(cn3.data_.getHero_p0().getHealth(), 30);
-		assertEquals(cn3.data_.getHero_p1().getHealth(), 30);
+		assertEquals(cn3.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(cn3.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(cn3.data_.getMinion_p0(0).getTotalHealth(), 3);
-		assertEquals(cn3.data_.getMinion_p0(1).getTotalHealth(), 4);
-		assertEquals(cn3.data_.getMinion_p0(2).getTotalHealth(), 3);
-		assertEquals(cn3.data_.getMinion_p0(3).getTotalHealth(), 6);
-//		assertEquals(cn3.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(cn3.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(cn3.data_.getMinion_p1(1).getTotalHealth(), 2);
-		assertEquals(cn3.data_.getMinion_p1(2).getTotalHealth(), 7);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 3);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 3);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 6);
+//		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 7);
 
-		assertEquals(cn3.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(cn3.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(cn3.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(cn3.data_.getMinion_p0(3).getTotalAttack(), 7);
-//		assertEquals(cn3.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(cn3.data_.getMinion_p1(0).getTotalAttack(), 5);
-		assertEquals(cn3.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(cn3.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(cn3.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
+//		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 5);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(cn3.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 	
 		//Fifth child node is the one that kills the Abomination
 		HearthTreeNode cn4 = ret.getChildren().get(4);
-		assertEquals(cn4.data_.getNumCards_hand_p0(), 0);
-		assertEquals(cn4.data_.getNumCards_hand_p1(), 1);
-		assertEquals(cn4.data_.getNumMinions_p0(), 4);
-		assertEquals(cn4.data_.getNumMinions_p1(), 1);
+		assertEquals(cn4.data_.getNumCardsHandCurrentPlayer(), 0);
+		assertEquals(cn4.data_.getNumCardsHandWaitingPlayer(), 1);
+		assertEquals(cn4.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(cn4.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(cn4.data_.getMana_p0(), 8);
 		assertEquals(cn4.data_.getMana_p1(), 10);
-		assertEquals(cn4.data_.getHero_p0().getHealth(), 28);
-		assertEquals(cn4.data_.getHero_p1().getHealth(), 28);
+		assertEquals(cn4.data_.getCurrentPlayerHero().getHealth(), 28);
+		assertEquals(cn4.data_.getWaitingPlayerHero().getHealth(), 28);
 		
-		assertEquals(cn4.data_.getMinion_p0(0).getTotalHealth(), 1);
-		assertEquals(cn4.data_.getMinion_p0(1).getTotalHealth(), 2);
-		assertEquals(cn4.data_.getMinion_p0(2).getTotalHealth(), 1);
-		assertEquals(cn4.data_.getMinion_p0(3).getTotalHealth(), 4);
-		assertEquals(cn4.data_.getMinion_p1(0).getTotalHealth(), 5);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 2);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 1);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 4);
+		assertEquals(cn4.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 5);
 
-		assertEquals(cn4.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(cn4.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(cn4.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(cn4.data_.getMinion_p0(3).getTotalAttack(), 7);
-		assertEquals(cn4.data_.getMinion_p1(0).getTotalAttack(), 6);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(cn4.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
+		assertEquals(cn4.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestDarkscaleHealer.java
+++ b/src/test/java/com/hearthsim/test/minion/TestDarkscaleHealer.java
@@ -31,11 +31,11 @@ public class TestDarkscaleHealer {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestDarkscaleHealer {
 		deck = new Deck(cards);
 
 		DarkscaleHealer fb = new DarkscaleHealer();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)5);
 		board.data_.setMana_p1((byte)4);
@@ -58,60 +58,60 @@ public class TestDarkscaleHealer {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		board.data_.getHero_p0().setHealth((byte)27);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		board.data_.getCurrentPlayerHero().setHealth((byte)27);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 0);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 29);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 29);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestDefenderOfArgus.java
+++ b/src/test/java/com/hearthsim/test/minion/TestDefenderOfArgus.java
@@ -31,11 +31,11 @@ public class TestDefenderOfArgus {
 		Minion minion1_0 = new BloodfenRaptor();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -52,16 +52,16 @@ public class TestDefenderOfArgus {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -70,7 +70,7 @@ public class TestDefenderOfArgus {
 		board.data_.resetMinions();
 		
 		Minion fb = new DefenderOfArgus();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
@@ -78,74 +78,74 @@ public class TestDefenderOfArgus {
 	@Test
 	public void test0() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 		
-		assertFalse(board.data_.getMinion_p0(0).getTaunt());
-		assertTrue(board.data_.getMinion_p0(1).getTaunt());
-		assertFalse(board.data_.getMinion_p0(2).getTaunt());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(0).getTaunt());
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTaunt());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(2).getTaunt());
 	}
 	
 	@Test
 	public void test1() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 8);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 8);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 		
-		assertTrue(board.data_.getMinion_p0(0).getTaunt());
-		assertFalse(board.data_.getMinion_p0(1).getTaunt());
-		assertTrue(board.data_.getMinion_p0(2).getTaunt());
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTaunt());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(1).getTaunt());
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTaunt());
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestDragonlingMechanic.java
+++ b/src/test/java/com/hearthsim/test/minion/TestDragonlingMechanic.java
@@ -30,11 +30,11 @@ public class TestDragonlingMechanic {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestDragonlingMechanic {
 		deck = new Deck(cards);
 
 		Card fb = new DragonlingMechanic();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -54,16 +54,16 @@ public class TestDragonlingMechanic {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -77,27 +77,27 @@ public class TestDragonlingMechanic {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	
@@ -105,30 +105,30 @@ public class TestDragonlingMechanic {
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 4);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(3).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestDreadInfernal.java
+++ b/src/test/java/com/hearthsim/test/minion/TestDreadInfernal.java
@@ -31,11 +31,11 @@ public class TestDreadInfernal {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestDreadInfernal {
 		deck = new Deck(cards);
 
 		Minion fb = new DreadInfernal();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -58,45 +58,45 @@ public class TestDreadInfernal {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 1);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 29);
-		assertEquals(board.data_.getHero_p1().getHealth(), 29);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0 - 1);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 6);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0 - 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 29);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 29);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - 1);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestDustDevil.java
+++ b/src/test/java/com/hearthsim/test/minion/TestDustDevil.java
@@ -29,11 +29,11 @@ public class TestDustDevil {
 		Minion minion1_0 = new AngryChicken();
 		Minion minion1_1 = new AngryChicken();
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -43,7 +43,7 @@ public class TestDustDevil {
 		deck = new Deck(cards);
 
 		Minion fb = new DustDevil();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)7);
@@ -56,53 +56,53 @@ public class TestDustDevil {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 7);
-		assertEquals(board.data_.getHero_p0().getTotalHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getTotalHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getTotalHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getTotalHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
 	}
 	
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 7);
 		
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 1);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 1);
 		
 		//overloaded for 2, so when resetMana is called, it should set the mana to 5
 		board.data_.resetMana();

--- a/src/test/java/com/hearthsim/test/minion/TestElvenArcher.java
+++ b/src/test/java/com/hearthsim/test/minion/TestElvenArcher.java
@@ -34,12 +34,12 @@ public class TestElvenArcher {
 		
 		minion1_2.setHealth((byte)1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
-		board.data_.placeMinion(1, minion1_2);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_2);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -49,7 +49,7 @@ public class TestElvenArcher {
 		deck = new Deck(cards);
 
 		Minion fb = new ElvenArcher();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -62,185 +62,185 @@ public class TestElvenArcher {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
 		
 		assertEquals(board.numChildren(), 7);
 		
 		{
 			HearthTreeNode child = board.getChildren().get(0);
 			assertEquals(child.data_.getNumCards_hand(), 0);
-			assertEquals(child.data_.getNumMinions_p0(), 3);
-			assertEquals(child.data_.getNumMinions_p1(), 3);
+			assertEquals(child.data_.getCurrentPlayer().getNumMinions(), 3);
+			assertEquals(child.data_.getWaitingPlayer().getNumMinions(), 3);
 			assertEquals(child.data_.getMana_p0(), 6);
 			assertEquals(child.data_.getMana_p1(), 4);
-			assertEquals(child.data_.getHero_p0().getHealth(), 29);
-			assertEquals(child.data_.getHero_p1().getHealth(), 30);
-			assertEquals(child.data_.getMinion_p0(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p0(1).getHealth(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getHealth(), health1 - 1);
-			assertEquals(child.data_.getMinion_p1(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p1(1).getHealth(), health1 - 1);
+			assertEquals(child.data_.getCurrentPlayerHero().getHealth(), 29);
+			assertEquals(child.data_.getWaitingPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 			
-			assertEquals(child.data_.getMinion_p0(0).getTotalAttack(), attack0);
-			assertEquals(child.data_.getMinion_p0(1).getTotalAttack(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
 		}		
 		
 		{
 			HearthTreeNode child = board.getChildren().get(1);
 			assertEquals(child.data_.getNumCards_hand(), 0);
-			assertEquals(child.data_.getNumMinions_p0(), 3);
-			assertEquals(child.data_.getNumMinions_p1(), 3);
+			assertEquals(child.data_.getCurrentPlayer().getNumMinions(), 3);
+			assertEquals(child.data_.getWaitingPlayer().getNumMinions(), 3);
 			assertEquals(child.data_.getMana_p0(), 6);
 			assertEquals(child.data_.getMana_p1(), 4);
-			assertEquals(child.data_.getHero_p0().getHealth(), 30);
-			assertEquals(child.data_.getHero_p1().getHealth(), 30);
-			assertEquals(child.data_.getMinion_p0(0).getHealth(), health0 - 1);
-			assertEquals(child.data_.getMinion_p0(1).getHealth(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getHealth(), health1 - 1);
-			assertEquals(child.data_.getMinion_p1(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p1(1).getHealth(), health1 - 1);
+			assertEquals(child.data_.getCurrentPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getWaitingPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0 - 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 			
-			assertEquals(child.data_.getMinion_p0(0).getTotalAttack(), attack0);
-			assertEquals(child.data_.getMinion_p0(1).getTotalAttack(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
 		}		
 
 		{
 			HearthTreeNode child = board.getChildren().get(2);
 			assertEquals(child.data_.getNumCards_hand(), 0);
-			assertEquals(child.data_.getNumMinions_p0(), 3);
-			assertEquals(child.data_.getNumMinions_p1(), 3);
+			assertEquals(child.data_.getCurrentPlayer().getNumMinions(), 3);
+			assertEquals(child.data_.getWaitingPlayer().getNumMinions(), 3);
 			assertEquals(child.data_.getMana_p0(), 6);
 			assertEquals(child.data_.getMana_p1(), 4);
-			assertEquals(child.data_.getHero_p0().getHealth(), 30);
-			assertEquals(child.data_.getHero_p1().getHealth(), 30);
-			assertEquals(child.data_.getMinion_p0(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p0(1).getHealth(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getHealth(), health1 - 1 - 1);
-			assertEquals(child.data_.getMinion_p1(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p1(1).getHealth(), health1 - 1);
+			assertEquals(child.data_.getCurrentPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getWaitingPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1 - 1);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 			
-			assertEquals(child.data_.getMinion_p0(0).getTotalAttack(), attack0);
-			assertEquals(child.data_.getMinion_p0(1).getTotalAttack(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
 		}		
 
 		{
 			HearthTreeNode child = board.getChildren().get(3);
 			assertEquals(child.data_.getNumCards_hand(), 0);
-			assertEquals(child.data_.getNumMinions_p0(), 3);
-			assertEquals(child.data_.getNumMinions_p1(), 3);
+			assertEquals(child.data_.getCurrentPlayer().getNumMinions(), 3);
+			assertEquals(child.data_.getWaitingPlayer().getNumMinions(), 3);
 			assertEquals(child.data_.getMana_p0(), 6);
 			assertEquals(child.data_.getMana_p1(), 4);
-			assertEquals(child.data_.getHero_p0().getHealth(), 30);
-			assertEquals(child.data_.getHero_p1().getHealth(), 29);
-			assertEquals(child.data_.getMinion_p0(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p0(1).getHealth(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getHealth(), health1 - 1);
-			assertEquals(child.data_.getMinion_p1(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p1(1).getHealth(), health1 - 1);
+			assertEquals(child.data_.getCurrentPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getWaitingPlayerHero().getHealth(), 29);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 			
-			assertEquals(child.data_.getMinion_p0(0).getTotalAttack(), attack0);
-			assertEquals(child.data_.getMinion_p0(1).getTotalAttack(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
 		}
 		
 		{
 			HearthTreeNode child = board.getChildren().get(4);
 			assertEquals(child.data_.getNumCards_hand(), 0);
-			assertEquals(child.data_.getNumMinions_p0(), 3);
-			assertEquals(child.data_.getNumMinions_p1(), 3);
+			assertEquals(child.data_.getCurrentPlayer().getNumMinions(), 3);
+			assertEquals(child.data_.getWaitingPlayer().getNumMinions(), 3);
 			assertEquals(child.data_.getMana_p0(), 6);
 			assertEquals(child.data_.getMana_p1(), 4);
-			assertEquals(child.data_.getHero_p0().getHealth(), 30);
-			assertEquals(child.data_.getHero_p1().getHealth(), 30);
-			assertEquals(child.data_.getMinion_p0(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p0(1).getHealth(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getHealth(), health1 - 1);
-			assertEquals(child.data_.getMinion_p1(0).getHealth(), health0 - 1);
-			assertEquals(child.data_.getMinion_p1(1).getHealth(), health1 - 1);
+			assertEquals(child.data_.getCurrentPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getWaitingPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0 - 1);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 			
-			assertEquals(child.data_.getMinion_p0(0).getTotalAttack(), attack0);
-			assertEquals(child.data_.getMinion_p0(1).getTotalAttack(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
 		}		
 
 		{
 			HearthTreeNode child = board.getChildren().get(5);
 			assertEquals(child.data_.getNumCards_hand(), 0);
-			assertEquals(child.data_.getNumMinions_p0(), 3);
-			assertEquals(child.data_.getNumMinions_p1(), 3);
+			assertEquals(child.data_.getCurrentPlayer().getNumMinions(), 3);
+			assertEquals(child.data_.getWaitingPlayer().getNumMinions(), 3);
 			assertEquals(child.data_.getMana_p0(), 6);
 			assertEquals(child.data_.getMana_p1(), 4);
-			assertEquals(child.data_.getHero_p0().getHealth(), 30);
-			assertEquals(child.data_.getHero_p1().getHealth(), 30);
-			assertEquals(child.data_.getMinion_p0(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p0(1).getHealth(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getHealth(), health1 - 1);
-			assertEquals(child.data_.getMinion_p1(0).getHealth(), health0);
-			assertEquals(child.data_.getMinion_p1(1).getHealth(), health1 - 1 - 1);
+			assertEquals(child.data_.getCurrentPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getWaitingPlayerHero().getHealth(), 30);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1 - 1);
 			
-			assertEquals(child.data_.getMinion_p0(0).getTotalAttack(), attack0);
-			assertEquals(child.data_.getMinion_p0(1).getTotalAttack(), 1);
-			assertEquals(child.data_.getMinion_p0(2).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
 		}		
 
 		{
 			HearthTreeNode child = board.getChildren().get(6);
 			assertEquals(child.data_.getNumCards_hand(), 0);
-			assertEquals(child.data_.getNumMinions_p0(), 2);
-			assertEquals(child.data_.getNumMinions_p1(), 2);
+			assertEquals(child.data_.getCurrentPlayer().getNumMinions(), 2);
+			assertEquals(child.data_.getWaitingPlayer().getNumMinions(), 2);
 			assertEquals(child.data_.getMana_p0(), 6);
 			assertEquals(child.data_.getMana_p1(), 4);
-			assertEquals(child.data_.getHero_p0().getHealth(), 28);
-			assertEquals(child.data_.getHero_p1().getHealth(), 28);
-			assertEquals(child.data_.getMinion_p0(0).getTotalHealth(), health0 - 2);
-			assertEquals(child.data_.getMinion_p0(1).getTotalHealth(), health1 - 1 - 2);
-			assertEquals(child.data_.getMinion_p1(0).getTotalHealth(), health0 - 2);
-			assertEquals(child.data_.getMinion_p1(1).getTotalHealth(), health1 - 1 - 2);
+			assertEquals(child.data_.getCurrentPlayerHero().getHealth(), 28);
+			assertEquals(child.data_.getWaitingPlayerHero().getHealth(), 28);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), health0 - 2);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), health1 - 1 - 2);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), health0 - 2);
+			assertEquals(child.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), health1 - 1 - 2);
 			
-			assertEquals(child.data_.getMinion_p0(0).getTotalAttack(), attack0);
-			assertEquals(child.data_.getMinion_p0(1).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+			assertEquals(child.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
 		}		
 
 	}

--- a/src/test/java/com/hearthsim/test/minion/TestFlesheatingGhoul.java
+++ b/src/test/java/com/hearthsim/test/minion/TestFlesheatingGhoul.java
@@ -31,14 +31,14 @@ public class TestFlesheatingGhoul {
 		Minion minion1_2 = new Abomination();
 		Minion minion1_3 = new LootHoarder();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
-		board.data_.placeCard_hand_p0(minion0_2);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_2);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
-		board.data_.placeCard_hand_p1(minion1_3);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_3);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -55,19 +55,19 @@ public class TestFlesheatingGhoul {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -76,7 +76,7 @@ public class TestFlesheatingGhoul {
 		board.data_.resetMinions();
 		
 		Minion fb = new FlesheatingGhoul();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
@@ -86,105 +86,105 @@ public class TestFlesheatingGhoul {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, deck);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 3);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, deck);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 4);
-		assertEquals(board.data_.getNumMinions_p1(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p0(3).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(3).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getAuraHealth(), 1);
 		
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 
 		
 		//---------------------------------------------------------------
-		Minion attacker = board.data_.getCharacter(0, 3);
-		target = board.data_.getCharacter(1, 2);
-		ret = attacker.attack(1, target, board, deck, deck);
+		Minion attacker = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		ret = attacker.attack(board.data_.getWaitingPlayer(), target, board, deck, deck);
 		
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 3);
-		assertEquals(ret.data_.getNumMinions_p1(), 1);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(ret.data_.getMana_p0(), 7);
 		assertEquals(ret.data_.getMana_p1(), 10);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 28); //2 damage from Abomination's deathrattle
-		assertEquals(ret.data_.getHero_p1().getHealth(), 28); //2 damage from Abomination's deathrattle
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 28); //2 damage from Abomination's deathrattle
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 28); //2 damage from Abomination's deathrattle
 		
-		assertEquals(ret.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalHealth(), 1);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalHealth(), 2);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalHealth(), 5);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 0);
 
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(ret.data_.getMinion_p0(2).getTotalAttack(), 4 + 4); //4 minions died
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 6);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4 + 4); //4 minions died
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
 
 	}
 

--- a/src/test/java/com/hearthsim/test/minion/TestFrostwolfWarlord.java
+++ b/src/test/java/com/hearthsim/test/minion/TestFrostwolfWarlord.java
@@ -31,11 +31,11 @@ public class TestFrostwolfWarlord {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestFrostwolfWarlord {
 		deck = new Deck(cards);
 
 		Minion fb = new FrostwolfWarlord();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -58,48 +58,48 @@ public class TestFrostwolfWarlord {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 4 + 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 4 + 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 4 + 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 4 + 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 
 }

--- a/src/test/java/com/hearthsim/test/minion/TestGnomishInventor.java
+++ b/src/test/java/com/hearthsim/test/minion/TestGnomishInventor.java
@@ -35,11 +35,11 @@ public class TestGnomishInventor {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -49,7 +49,7 @@ public class TestGnomishInventor {
 		deck = new Deck(cards);
 
 		Minion fb = new GnomishInventor();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)7);
@@ -62,28 +62,28 @@ public class TestGnomishInventor {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue( ret instanceof CardDrawNode );
@@ -92,23 +92,23 @@ public class TestGnomishInventor {
 		
 		assertEquals(cNode.getNumCardsToDraw(), 1);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 7);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 	
 	@Test
@@ -130,13 +130,13 @@ public class TestGnomishInventor {
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 1); //1 card drawn from GnomishInventor, not enough mana to play it
-		assertEquals(resBoard.getNumMinions_p0(), 3);
-		assertEquals(resBoard.getNumMinions_p1(), 1); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 1); //1 card drawn from GnomishInventor, not enough mana to play it
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 1); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 1); //4 mana used for Gnomish Inventor
 		assertEquals(resBoard.getMana_p1(), 5);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 25); //smacked in the face once
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 25); //smacked in the face once
 	}
 	
 	@Test
@@ -150,12 +150,12 @@ public class TestGnomishInventor {
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 0); //1 card drawn from GnomishInventor, and had enough mana to play it
-		assertEquals(resBoard.getNumMinions_p0(), 4);
-		assertEquals(resBoard.getNumMinions_p1(), 1); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 0); //1 card drawn from GnomishInventor, and had enough mana to play it
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 1); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 1); //4 mana used for Gnomish Inventor, 2 for Bloodfen Raptor
 		assertEquals(resBoard.getMana_p1(), 7);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 25); //smacked in the face once
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 25); //smacked in the face once
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestGrimscaleOracle.java
+++ b/src/test/java/com/hearthsim/test/minion/TestGrimscaleOracle.java
@@ -31,11 +31,11 @@ public class TestGrimscaleOracle {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestGrimscaleOracle {
 		deck = new Deck(cards);
 
 		Minion fb = new GrimscaleOracle();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -58,79 +58,79 @@ public class TestGrimscaleOracle {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 
 	@Test
 	public void test3() throws HSException {
 		
-		board.data_.placeMinion(0, new MurlocRaider());
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), new MurlocRaider());
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 4);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p0(3).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestGurubashiBerserker.java
+++ b/src/test/java/com/hearthsim/test/minion/TestGurubashiBerserker.java
@@ -31,11 +31,11 @@ public class TestGurubashiBerserker {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestGurubashiBerserker {
 		deck = new Deck(cards);
 
 		Minion fb = new GurubashiBerserker();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)7);
 		board.data_.setMana_p1((byte)4);
@@ -58,100 +58,100 @@ public class TestGurubashiBerserker {
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 	}
 
 	@Test
 	public void test3() throws HSException {
 			
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 2);
 		assertEquals(board.data_.getMana_p1(), 4);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), health1 - 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), health1 - 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), attack0);
 		
 		HearthTreeNode flipped = new HearthTreeNode(board.data_.flipPlayers());
-		Minion minion = flipped.data_.getMinion_p0(0);
-		target = flipped.data_.getCharacter(1, 2);
-		ret = minion.attack(1, target, flipped, deck, null);
+		Minion minion = flipped.data_.getCurrentPlayer().getMinions().get(0);
+		target = flipped.data_.getCharacter(flipped.data_.getWaitingPlayer(), 2);
+		ret = minion.attack(flipped.data_.getWaitingPlayer(), target, flipped, deck, null);
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 2);
-		assertEquals(ret.data_.getNumMinions_p1(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(ret.data_.getMana_p0(), 4);
 		assertEquals(ret.data_.getMana_p1(), 2);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
-		assertEquals(ret.data_.getMinion_p1(0).getHealth(), health0);
-		assertEquals(ret.data_.getMinion_p1(1).getHealth(), 7 - attack0);
-		assertEquals(ret.data_.getMinion_p1(2).getHealth(), health1 - 1);
-		assertEquals(ret.data_.getMinion_p0(0).getHealth(), health0 - 2);
-		assertEquals(ret.data_.getMinion_p0(1).getHealth(), health1 - 1);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth(), health0);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7 - attack0);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getHealth(), health1 - 1);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth(), health0 - 2);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getHealth(), health1 - 1);
 
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), attack0);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalAttack(), attack0);
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), attack0);
-		assertEquals(ret.data_.getMinion_p0(1).getTotalAttack(), attack0);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), attack0);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), attack0);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), attack0);
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestHoundmaster.java
+++ b/src/test/java/com/hearthsim/test/minion/TestHoundmaster.java
@@ -33,12 +33,12 @@ public class TestHoundmaster {
 		Minion minion4 = new Minion("" + 0, mana, attack0, (byte)(health0-2), attack0, health0, health0);
 
 		Houndmaster fb = new Houndmaster();
-		board.data_.placeCard_hand_p0(fb);
-		board.data_.placeMinion(0, minion0);
-		board.data_.placeMinion(0, minion1);
-		board.data_.placeMinion(1, minion2);
-		board.data_.placeMinion(1, minion3);
-		board.data_.placeMinion(1, minion4);
+		board.data_.placeCardHandCurrentPlayer(fb);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion2);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion3);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion4);
 		
 		board.data_.setMana_p0(10);
 	}
@@ -91,65 +91,65 @@ public class TestHoundmaster {
 
 		Deck deck = null;
 		
-		Card theCard = board.data_.getCard_hand_p0(0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
 		HearthTreeNode res;
 		Minion target = null;
 		
-		target = board.data_.getCharacter(1, 0);
-		res = theCard.useOn(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		res = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertTrue(res == null);
 		
-		target = board.data_.getCharacter(0, 0);
-		res = theCard.useOn(0, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		res = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(res == null);
 		assertTrue(res.data_.getNumCards_hand() == 0);
-		assertTrue(res.data_.getNumMinions_p0() == 3);
-		assertTrue(res.data_.getNumMinions_p1() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(res.data_.getWaitingPlayer().getNumMinions() == 3);
 		assertTrue(res.data_.getMana_p0() == 6);
 		
-		assertTrue(res.data_.getMinion_p0(0).getHealth() == 3);
-		assertTrue(res.data_.getMinion_p0(0).getTotalAttack() == 4);
-		assertFalse(res.data_.getMinion_p0(0).getTaunt());
-		assertTrue(res.data_.getMinion_p0(1).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertFalse(res.data_.getMinion_p0(1).getTaunt());
-		assertTrue(res.data_.getMinion_p0(2).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p0(2).getTotalAttack() == attack0);
-		assertFalse(res.data_.getMinion_p0(2).getTaunt());
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 3);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == 4);
+		assertFalse(res.data_.getCurrentPlayer().getMinions().get(0).getTaunt());
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(res.data_.getCurrentPlayer().getMinions().get(1).getTaunt());
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(2).getHealth() == health0);
+		assertTrue(res.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertFalse(res.data_.getCurrentPlayer().getMinions().get(2).getTaunt());
 
-		assertTrue(res.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertFalse(res.data_.getMinion_p1(0).getTaunt());
-		assertTrue(res.data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(res.data_.getMinion_p1(1).getTaunt());
-		assertTrue(res.data_.getMinion_p1(2).getHealth() == health0-2);
-		assertTrue(res.data_.getMinion_p1(2).getTotalAttack() == attack0);
-		assertFalse(res.data_.getMinion_p1(2).getTaunt());
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertFalse(res.data_.getWaitingPlayer().getMinions().get(0).getTaunt());
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(res.data_.getWaitingPlayer().getMinions().get(1).getTaunt());
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0-2);
+		assertTrue(res.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertFalse(res.data_.getWaitingPlayer().getMinions().get(2).getTaunt());
 		
-		assertTrue(res.data_.getHero_p0().getHealth() == 30);
-		assertTrue(res.data_.getHero_p1().getHealth() == 30);
+		assertTrue(res.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(res.data_.getWaitingPlayerHero().getHealth() == 30);
 
 		assertTrue(res.numChildren() == 1);
-		assertTrue(res.getChildren().get(0).data_.getMinion_p0(0).getHealth() == 3);
-		assertTrue(res.getChildren().get(0).data_.getMinion_p0(0).getTotalAttack() == 4);
-		assertFalse(res.getChildren().get(0).data_.getMinion_p0(0).getTaunt());
-		assertTrue(res.getChildren().get(0).data_.getMinion_p0(1).getHealth() == health0);
-		assertTrue(res.getChildren().get(0).data_.getMinion_p0(1).getTotalAttack() == attack0);
-		assertFalse(res.getChildren().get(0).data_.getMinion_p0(1).getTaunt());
-		assertTrue(res.getChildren().get(0).data_.getMinion_p0(2).getHealth() == health0 + 2);
-		assertTrue(res.getChildren().get(0).data_.getMinion_p0(2).getTotalAttack() == attack0 + 2);
-		assertTrue(res.getChildren().get(0).data_.getMinion_p0(2).getTaunt());
+		assertTrue(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(0).getHealth() == 3);
+		assertTrue(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(0).getTotalAttack() == 4);
+		assertFalse(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(0).getTaunt());
+		assertTrue(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(1).getTaunt());
+		assertTrue(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(2).getHealth() == health0 + 2);
+		assertTrue(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(2).getTotalAttack() == attack0 + 2);
+		assertTrue(res.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(2).getTaunt());
 		
-		assertTrue(res.getChildren().get(0).data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(res.getChildren().get(0).data_.getMinion_p1(0).getTotalAttack() == attack0);
-		assertFalse(res.getChildren().get(0).data_.getMinion_p1(0).getTaunt());
-		assertTrue(res.getChildren().get(0).data_.getMinion_p1(1).getHealth() == health1);
-		assertTrue(res.getChildren().get(0).data_.getMinion_p1(1).getTotalAttack() == attack0);
-		assertFalse(res.getChildren().get(0).data_.getMinion_p1(1).getTaunt());
-		assertTrue(res.getChildren().get(0).data_.getMinion_p1(2).getHealth() == health0-2);
-		assertTrue(res.getChildren().get(0).data_.getMinion_p1(2).getTotalAttack() == attack0);
-		assertFalse(res.getChildren().get(0).data_.getMinion_p1(2).getTaunt());
+		assertTrue(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(0).getTotalAttack() == attack0);
+		assertFalse(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(0).getTaunt());
+		assertTrue(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(1).getTotalAttack() == attack0);
+		assertFalse(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(1).getTaunt());
+		assertTrue(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(2).getHealth() == health0-2);
+		assertTrue(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(2).getTotalAttack() == attack0);
+		assertFalse(res.getChildren().get(0).data_.getWaitingPlayer().getMinions().get(2).getTaunt());
 		
 	}
 

--- a/src/test/java/com/hearthsim/test/minion/TestIronbeakOwl.java
+++ b/src/test/java/com/hearthsim/test/minion/TestIronbeakOwl.java
@@ -38,14 +38,14 @@ public class TestIronbeakOwl {
 		Minion minion1_2 = new Abomination();
 		Minion minion1_3 = new LootHoarder();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
-		board.data_.placeCard_hand_p0(minion0_2);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_2);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
-		board.data_.placeCard_hand_p1(minion1_3);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_3);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -62,19 +62,19 @@ public class TestIronbeakOwl {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -83,7 +83,7 @@ public class TestIronbeakOwl {
 		board.data_.resetMinions();
 		
 		Minion fb = new IronbeakOwl();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
@@ -93,74 +93,74 @@ public class TestIronbeakOwl {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, deck);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(board.data_.getMana_p0(), 10);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
 		
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 3);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, deck);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, deck);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 4);
-		assertEquals(board.data_.getNumMinions_p1(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 10);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p0(3).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 2);
 		
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 		
 		assertEquals(ret.numChildren(), 7);
 
@@ -170,96 +170,96 @@ public class TestIronbeakOwl {
 
 		HearthTreeNode ret0 = ret.getChildren().get(0);
 		assertEquals(ret0.data_.getNumCards_hand(), 0);
-		assertEquals(ret0.data_.getNumMinions_p0(), 4);
-		assertEquals(ret0.data_.getNumMinions_p1(), 4);
+		assertEquals(ret0.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(ret0.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(ret0.data_.getMana_p0(), 8);
 		assertEquals(ret0.data_.getMana_p1(), 10);
-		assertEquals(ret0.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret0.data_.getHero_p1().getHealth(), 30);
+		assertEquals(ret0.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret0.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(ret0.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(ret0.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(ret0.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(ret0.data_.getMinion_p0(3).getTotalHealth(), 2);
+		assertEquals(ret0.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(ret0.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(ret0.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(ret0.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 2);
 		
-		assertEquals(ret0.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(ret0.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(ret0.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(ret0.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(ret0.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(ret0.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(ret0.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(ret0.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(ret0.data_.getMinion_p0(0).getTotalAttack(), 4);
-		assertEquals(ret0.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(ret0.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(ret0.data_.getMinion_p0(3).getTotalAttack(), 4);
+		assertEquals(ret0.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(ret0.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(ret0.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(ret0.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 4);
 		
-		assertEquals(ret0.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(ret0.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(ret0.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(ret0.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(ret0.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret0.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(ret0.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(ret0.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 
 		//------------------------------------------------------------------
 		//------------------------------------------------------------------
 
 		HearthTreeNode ret1 = ret.getChildren().get(1);
 		assertEquals(ret1.data_.getNumCards_hand(), 0);
-		assertEquals(ret1.data_.getNumMinions_p0(), 4);
-		assertEquals(ret1.data_.getNumMinions_p1(), 4);
+		assertEquals(ret1.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(ret1.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(ret1.data_.getMana_p0(), 8);
 		assertEquals(ret1.data_.getMana_p1(), 10);
-		assertEquals(ret1.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret1.data_.getHero_p1().getHealth(), 30);
+		assertEquals(ret1.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret1.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(ret1.data_.getMinion_p0(0).getTotalHealth(), 4);
-		assertEquals(ret1.data_.getMinion_p0(1).getTotalHealth(), 3);
-		assertEquals(ret1.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(ret1.data_.getMinion_p0(3).getTotalHealth(), 2);
+		assertEquals(ret1.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 4);
+		assertEquals(ret1.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 3);
+		assertEquals(ret1.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(ret1.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 2);
 		
-		assertEquals(ret1.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(ret1.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(ret1.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(ret1.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(ret1.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(ret1.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(ret1.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(ret1.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(ret1.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(ret1.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(ret1.data_.getMinion_p0(2).getTotalAttack(), 6);
-		assertEquals(ret1.data_.getMinion_p0(3).getTotalAttack(), 3);
+		assertEquals(ret1.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret1.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(ret1.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 6);
+		assertEquals(ret1.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 3);
 		
-		assertEquals(ret1.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(ret1.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(ret1.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(ret1.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(ret1.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret1.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(ret1.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(ret1.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 
 		//------------------------------------------------------------------
 		//------------------------------------------------------------------
 
 		HearthTreeNode ret2 = ret.getChildren().get(2);
 		assertEquals(ret2.data_.getNumCards_hand(), 0);
-		assertEquals(ret2.data_.getNumMinions_p0(), 4);
-		assertEquals(ret2.data_.getNumMinions_p1(), 4);
+		assertEquals(ret2.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(ret2.data_.getWaitingPlayer().getNumMinions(), 4);
 		assertEquals(ret2.data_.getMana_p0(), 8);
 		assertEquals(ret2.data_.getMana_p1(), 10);
-		assertEquals(ret2.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret2.data_.getHero_p1().getHealth(), 30);
+		assertEquals(ret2.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret2.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertEquals(ret2.data_.getMinion_p0(0).getTotalHealth(), 3);
-		assertEquals(ret2.data_.getMinion_p0(1).getTotalHealth(), 2);
-		assertEquals(ret2.data_.getMinion_p0(2).getTotalHealth(), 6);
-		assertEquals(ret2.data_.getMinion_p0(3).getTotalHealth(), 1);
+		assertEquals(ret2.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 3);
+		assertEquals(ret2.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 2);
+		assertEquals(ret2.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 6);
+		assertEquals(ret2.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth(), 1);
 		
-		assertEquals(ret2.data_.getMinion_p1(0).getTotalHealth(), 1);
-		assertEquals(ret2.data_.getMinion_p1(1).getTotalHealth(), 4);
-		assertEquals(ret2.data_.getMinion_p1(2).getTotalHealth(), 2);
-		assertEquals(ret2.data_.getMinion_p1(3).getTotalHealth(), 7);
+		assertEquals(ret2.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 1);
+		assertEquals(ret2.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 4);
+		assertEquals(ret2.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(ret2.data_.getWaitingPlayer().getMinions().get(3).getTotalHealth(), 7);
 
-		assertEquals(ret2.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(ret2.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(ret2.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(ret2.data_.getMinion_p0(3).getTotalAttack(), 3);
+		assertEquals(ret2.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret2.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(ret2.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(ret2.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 3);
 		
-		assertEquals(ret2.data_.getMinion_p1(0).getTotalAttack(), 3);
-		assertEquals(ret2.data_.getMinion_p1(1).getTotalAttack(), 5);
-		assertEquals(ret2.data_.getMinion_p1(2).getTotalAttack(), 2);
-		assertEquals(ret2.data_.getMinion_p1(3).getTotalAttack(), 7);
+		assertEquals(ret2.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(ret2.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 5);
+		assertEquals(ret2.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 2);
+		assertEquals(ret2.data_.getWaitingPlayer().getMinions().get(3).getTotalAttack(), 7);
 
 		//------------------------------------------------------------------
 		//------------------------------------------------------------------

--- a/src/test/java/com/hearthsim/test/minion/TestLeperGnome.java
+++ b/src/test/java/com/hearthsim/test/minion/TestLeperGnome.java
@@ -30,12 +30,12 @@ public class TestLeperGnome {
 		Minion minion1_1 = new RaidLeader();
 		Minion minion1_2 = new LeperGnome();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_2);
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestLeperGnome {
 		deck = new Deck(cards);
 
 		Card fb = new LeperGnome();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -55,17 +55,17 @@ public class TestLeperGnome {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -81,115 +81,115 @@ public class TestLeperGnome {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 3);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 3);
 		
 		
 		
 		//----------------------------------------------------------
 		
-		Minion minion = board.data_.getMinion_p0(2);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(2);
 		assertTrue(minion instanceof LeperGnome);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7 - 3);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7 - 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 3);
 
 		//----------------------------------------------------------
 		
-		minion = board.data_.getMinion_p0(1);
+		minion = board.data_.getCurrentPlayer().getMinions().get(1);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 3);
-		minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 28);
-		assertEquals(board.data_.getHero_p1().getHealth(), 28);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7 - 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7 - 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 28);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7 - 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7 - 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 

--- a/src/test/java/com/hearthsim/test/minion/TestLootHorder.java
+++ b/src/test/java/com/hearthsim/test/minion/TestLootHorder.java
@@ -30,9 +30,9 @@ public class TestLootHorder {
 		Minion minion0_0 = new LootHoarder();
 		Minion minion1_0 = new BloodfenRaptor();
 		
-		board.data_.placeMinion(0, minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
 		
-		board.data_.placeMinion(1, minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -63,13 +63,13 @@ public class TestLootHorder {
 
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 1); //1 card drawn from Loot Horder attacking and dying, no mana left to play the card
-		assertEquals(resBoard.getNumMinions_p0(), 0);
-		assertEquals(resBoard.getNumMinions_p1(), 0); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 1); //1 card drawn from Loot Horder attacking and dying, no mana left to play the card
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 0);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 0); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 1); //no mana used
 		assertEquals(resBoard.getMana_p1(), 1);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 30);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 30);
 	}
 	
 
@@ -91,13 +91,13 @@ public class TestLootHorder {
 
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 0); //1 card drawn from Loot Horder attacking and dying, then played the drawn card
-		assertEquals(resBoard.getNumMinions_p0(), 1);
-		assertEquals(resBoard.getNumMinions_p1(), 0); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 0); //1 card drawn from Loot Horder attacking and dying, then played the drawn card
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 0); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 1); //2 mana used
 		assertEquals(resBoard.getMana_p1(), 3);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 30);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 30);
 	}
 	
 	@Test
@@ -106,12 +106,12 @@ public class TestLootHorder {
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		
 		//remove the loot hoarder from player0, add a Wisp
-		board.data_.removeMinion(0, 0);
-		board.data_.placeMinion(0, new Wisp());
+		board.data_.removeMinion(board.data_.getCurrentPlayer(), 0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), new Wisp());
 		
 		//remove the Bloodfen Raptor from player0, add a Loot Hoarder
-		board.data_.removeMinion(1, 0);
-		board.data_.placeMinion(1, new LootHoarder());
+		board.data_.removeMinion(board.data_.getWaitingPlayer(), 0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), new LootHoarder());
 
 		Hero hero = new Hero();
 		PlayerModel playerModel0 = new PlayerModel("player0", hero, deck);
@@ -126,13 +126,13 @@ public class TestLootHorder {
 
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 		
-		assertEquals(resBoard.getNumCards_hand_p0(), 0); //no cards in hand
-		assertEquals(resBoard.getNumCards_hand_p1(), 1); //drew cards from the loot horder that was killed
-		assertEquals(resBoard.getNumMinions_p0(), 0);
-		assertEquals(resBoard.getNumMinions_p1(), 0); //1 minion should have been killed
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 0); //no cards in hand
+		assertEquals(resBoard.getNumCardsHandWaitingPlayer(), 1); //drew cards from the loot horder that was killed
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 0);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 0); //1 minion should have been killed
 		assertEquals(resBoard.getMana_p0(), 3); //no mana used
 		assertEquals(resBoard.getMana_p1(), 3);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 30);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 30);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestNorthshireCleric.java
+++ b/src/test/java/com/hearthsim/test/minion/TestNorthshireCleric.java
@@ -33,11 +33,11 @@ public class TestNorthshireCleric {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -93,66 +93,66 @@ public class TestNorthshireCleric {
 	@Test
 	public void test1() throws HSException {
 		NorthshireCleric fb = new NorthshireCleric();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 
 		assertTrue(ret.data_.getNumCards_hand() == 0);
-		assertTrue(ret.data_.getNumMinions_p0() == 3);
-		assertTrue(ret.data_.getNumMinions_p1() == 2);
-		assertTrue(ret.data_.getHero_p0().getHealth() == 30);
-		assertTrue(ret.data_.getHero_p1().getHealth() == 30);
-		assertTrue(ret.data_.getMinion_p0(0).getHealth() == 3);
-		assertTrue(ret.data_.getMinion_p0(1).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p0(2).getHealth() == health1 - 1);
-		assertTrue(ret.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(ret.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(ret.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 3);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(2).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
 		
 		
 		AncestralHealing ah = new AncestralHealing();
-		board.data_.placeCard_hand_p0(ah);
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 1);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(ah);
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue(ret.data_.getNumCards_hand() == 0);
-		assertTrue(ret.data_.getNumMinions_p0() == 3);
-		assertTrue(ret.data_.getNumMinions_p1() == 2);
-		assertTrue(ret.data_.getHero_p0().getHealth() == 30);
-		assertTrue(ret.data_.getHero_p1().getHealth() == 30);
-		assertTrue(ret.data_.getMinion_p0(0).getHealth() == 3);
-		assertTrue(ret.data_.getMinion_p0(1).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p0(2).getHealth() == health1 - 1);
-		assertTrue(ret.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(ret.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(ret.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 3);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(2).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
 		
 		
 		
 		ah = new AncestralHealing();
-		board.data_.placeCard_hand_p0(ah);
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 3);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(ah);
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals( ((CardDrawNode)ret).getNumCardsToDraw(), 1); //Northshire Cleric should have drawn a card, so 1 card now
-		assertTrue(ret.data_.getNumMinions_p0() == 3);
-		assertTrue(ret.data_.getNumMinions_p1() == 2);
-		assertTrue(ret.data_.getHero_p0().getHealth() == 30);
-		assertTrue(ret.data_.getHero_p1().getHealth() == 30);
-		assertTrue(ret.data_.getMinion_p0(0).getHealth() == 3);
-		assertTrue(ret.data_.getMinion_p0(1).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p0(2).getHealth() == health1);
-		assertTrue(ret.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(ret.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(ret.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 3);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health0);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(2).getHealth() == health1);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
 	}
 	
@@ -161,52 +161,52 @@ public class TestNorthshireCleric {
 		NorthshireCleric fb1 = new NorthshireCleric();
 		NorthshireCleric fb2 = new NorthshireCleric();
 
-		board.data_.placeCard_hand_p0(fb1);
-		board.data_.placeCard_hand_p0(fb2);
+		board.data_.placeCardHandCurrentPlayer(fb1);
+		board.data_.placeCardHandCurrentPlayer(fb2);
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 3);
-		ret = theCard.useOn(0, target, board, deck, null);
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 
 		assertTrue(ret.data_.getNumCards_hand() == 0);
-		assertTrue(ret.data_.getNumMinions_p0() == 4);
-		assertTrue(ret.data_.getNumMinions_p1() == 2);
-		assertTrue(ret.data_.getHero_p0().getHealth() == 30);
-		assertTrue(ret.data_.getHero_p1().getHealth() == 30);
-		assertTrue(ret.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(ret.data_.getMinion_p0(2).getHealth() == 3);
-		assertTrue(ret.data_.getMinion_p0(3).getHealth() == 3);
-		assertTrue(ret.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getCurrentPlayer().getNumMinions() == 4);
+		assertTrue(ret.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(ret.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(2).getHealth() == 3);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(3).getHealth() == 3);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
 		
 		AncestralHealing ah = new AncestralHealing();
-		board.data_.placeCard_hand_p0(ah);
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 2);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(ah);
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(ret.data_.getNumCards_hand(), 0);
 		assertTrue(ret instanceof CardDrawNode);
 		assertEquals( ((CardDrawNode)ret).getNumCardsToDraw(), 2); //Two clerics, one heal means 2 new cards
 
-		assertTrue(ret.data_.getNumMinions_p0() == 4);
-		assertTrue(ret.data_.getNumMinions_p1() == 2);
-		assertTrue(ret.data_.getHero_p0().getHealth() == 30);
-		assertTrue(ret.data_.getHero_p1().getHealth() == 30);
-		assertTrue(ret.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p0(1).getHealth() == health1);
-		assertTrue(ret.data_.getMinion_p0(2).getHealth() == 3);
-		assertTrue(ret.data_.getMinion_p0(3).getHealth() == 3);
-		assertTrue(ret.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(ret.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(ret.data_.getCurrentPlayer().getNumMinions() == 4);
+		assertTrue(ret.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(ret.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(2).getHealth() == 3);
+		assertTrue(ret.data_.getCurrentPlayer().getMinions().get(3).getHealth() == 3);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestRaidLeader.java
+++ b/src/test/java/com/hearthsim/test/minion/TestRaidLeader.java
@@ -31,11 +31,11 @@ public class TestRaidLeader {
 		Minion minion1_0 = new BloodfenRaptor();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -52,16 +52,16 @@ public class TestRaidLeader {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -70,39 +70,39 @@ public class TestRaidLeader {
 		board.data_.resetMinions();
 		
 		Minion fb = new RaidLeader();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
 	@Test
 	public void test1() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(2).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
 	}
 	
@@ -110,184 +110,184 @@ public class TestRaidLeader {
 	@Test
 	public void test2() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
 		
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(2).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
 		
 		
-		board.data_.placeCard_hand_p0(new HolySmite());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(1, 1);
-		ret = theCard.useOn(1, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new HolySmite());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
 	}
 	
 
 	@Test
 	public void test3() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(2).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
 		
 		
-		board.data_.placeCard_hand_p0(new Silence());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(1, 1);
-		ret = theCard.useOn(1, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new Silence());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(2).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 3);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 0);
 		
-		board.data_.placeCard_hand_p0(new Silence());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 1);
-		ret = theCard.useOn(0, target, board, deck, null);
-		
-		assertFalse(ret == null);
-		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(2).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == 2);
-		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 3);
-		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 0);
-		
-		board.data_.placeCard_hand_p0(new BloodfenRaptor());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 3);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new Silence());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 4);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(2).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(3).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 3);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(3).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 0);
+		
+		board.data_.placeCardHandCurrentPlayer(new BloodfenRaptor());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
+		
+		assertFalse(ret == null);
+		assertTrue(board.data_.getNumCards_hand() == 0);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 4);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(3).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == 2);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 3);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 0);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestScarletCrusader.java
+++ b/src/test/java/com/hearthsim/test/minion/TestScarletCrusader.java
@@ -30,12 +30,12 @@ public class TestScarletCrusader {
 		Minion minion1_1 = new RaidLeader();
 		Minion minion1_2 = new ScarletCrusader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestScarletCrusader {
 		deck = new Deck(cards);
 
 		Card fb = new ScarletCrusader();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -55,17 +55,17 @@ public class TestScarletCrusader {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -81,31 +81,31 @@ public class TestScarletCrusader {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 	
 	
@@ -113,157 +113,157 @@ public class TestScarletCrusader {
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
-		assertTrue(board.data_.getMinion_p0(2).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getDivineShield());
 		
 		//------------------------------------------------------------
 		//Attacking with divine shield vs Hero, divine shield should
 		// stay on
 		//------------------------------------------------------------
-		target = board.data_.getCharacter(1, 0);
-		Minion m0 = board.data_.getMinion_p0(2);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Minion m0 = board.data_.getCurrentPlayer().getMinions().get(2);
 		m0.hasAttacked(false);
-		ret = m0.attack(1, target, board, deck, null);
+		ret = m0.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
-		assertTrue(board.data_.getMinion_p0(2).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getDivineShield());
 		
 		//------------------------------------------------------------
 		//Attacking with divine shield
 		//------------------------------------------------------------
-		target = board.data_.getCharacter(1, 3);
-		Minion m1 = board.data_.getMinion_p0(2);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		Minion m1 = board.data_.getCurrentPlayer().getMinions().get(2);
 		m1.hasAttacked(false);
-		ret = m1.attack(1, target, board, deck, null);
+		ret = m1.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
-		assertFalse(board.data_.getMinion_p0(2).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(2).getDivineShield());
 		
 		//------------------------------------------------------------
 		//Being attacked with a divine shield
 		//------------------------------------------------------------
-		target = board.data_.getCharacter(1, 1);
-		Minion m2 = board.data_.getMinion_p0(1);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		Minion m2 = board.data_.getCurrentPlayer().getMinions().get(1);
 		m2.hasAttacked(false);
-		ret = m2.attack(1, target, board, deck, null);
+		ret = m2.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertFalse(board.data_.getMinion_p1(0).getDivineShield());
-		assertFalse(board.data_.getMinion_p0(2).getDivineShield());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
+		assertFalse(board.data_.getCurrentPlayer().getMinions().get(2).getDivineShield());
 		
 		//------------------------------------------------------------
 		//Being attacked with a divine shield that wore off
 		//------------------------------------------------------------
-		target = board.data_.getCharacter(1, 3);
-		Minion m3 = board.data_.getMinion_p0(2);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		Minion m3 = board.data_.getCurrentPlayer().getMinions().get(2);
 		m3.hasAttacked(false);
-		ret = m3.attack(1, target, board, deck, null);
+		ret = m3.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 26);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 26);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
 		
-		assertFalse(board.data_.getMinion_p1(0).getDivineShield());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestShatteredSunCleric.java
+++ b/src/test/java/com/hearthsim/test/minion/TestShatteredSunCleric.java
@@ -31,12 +31,12 @@ public class TestShatteredSunCleric {
 		Minion minion1_1 = new RaidLeader();
 		Minion minion1_2 = new ScarletCrusader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestShatteredSunCleric {
 		deck = new Deck(cards);
 
 		Card fb = new ShatteredSunCleric();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -56,17 +56,17 @@ public class TestShatteredSunCleric {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -82,75 +82,75 @@ public class TestShatteredSunCleric {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 	
 	
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 5);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 
 		//At this point, the BoardState should have 2 children: one that buffs the Raid Leader
 		//and another that buffs the Boulderfist Ogre
 		assertEquals(board.numChildren(), 2);
 		
-		assertEquals(board.getChildren().get(0).data_.getMinion_p0(0).getTotalAttack(), 3);
-		assertEquals(board.getChildren().get(0).data_.getMinion_p0(0).getHealth(), 3);
-		assertEquals(board.getChildren().get(0).data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.getChildren().get(0).data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.getChildren().get(1).data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.getChildren().get(1).data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.getChildren().get(1).data_.getMinion_p0(1).getTotalAttack(), 8);
-		assertEquals(board.getChildren().get(1).data_.getMinion_p0(1).getHealth(), 8);
+		assertEquals(board.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 3);
+		assertEquals(board.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(0).getHealth(), 3);
+		assertEquals(board.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.getChildren().get(0).data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.getChildren().get(1).data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.getChildren().get(1).data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.getChildren().get(1).data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 8);
+		assertEquals(board.getChildren().get(1).data_.getCurrentPlayer().getMinions().get(1).getHealth(), 8);
 
 		
 	}

--- a/src/test/java/com/hearthsim/test/minion/TestStormwindChampion.java
+++ b/src/test/java/com/hearthsim/test/minion/TestStormwindChampion.java
@@ -32,11 +32,11 @@ public class TestStormwindChampion {
 		Minion minion1_0 = new BloodfenRaptor();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -53,16 +53,16 @@ public class TestStormwindChampion {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -71,46 +71,46 @@ public class TestStormwindChampion {
 		board.data_.resetMinions();
 		
 		Minion fb = new StormwindChampion();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
 	@Test
 	public void test1() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
 		
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getTotalHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
 
 	}
 	
@@ -118,73 +118,73 @@ public class TestStormwindChampion {
 	@Test
 	public void test2() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
 		
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getTotalHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
 
 		
 		
-		board.data_.placeCard_hand_p0(new Fireball());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(1, 1);
-		ret = theCard.useOn(1, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new Fireball());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
 		
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 3);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
 
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
 
 	}
 	
@@ -192,268 +192,268 @@ public class TestStormwindChampion {
 	@Test
 	public void test3() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
 
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getTotalHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
 
 		
 		
-		board.data_.placeCard_hand_p0(new Silence());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(1, 1);
-		ret = theCard.useOn(1, target, board, deck, null);
-		
-		assertFalse(ret == null);
-		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getTotalHealth() == 2);
-		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 3);
-		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 0);
-
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
-		
-		
-		board.data_.placeCard_hand_p0(new Silence());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 1);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new Silence());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth() == 2);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 3);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 0);
 
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getTotalHealth() == 2);
-		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 3);
-		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 0);
-
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
 		
 		
-		
-		board.data_.placeCard_hand_p0(new BloodfenRaptor());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 3);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new Silence());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 4);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p0(3).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getTotalHealth() == 2);
-		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 3);
-		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(3).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 0);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
 
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(3).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth() == 2);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 3);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 0);
+
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
+		
+		
+		
+		board.data_.placeCardHandCurrentPlayer(new BloodfenRaptor());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 3);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
+		
+		assertFalse(ret == null);
+		assertTrue(board.data_.getNumCards_hand() == 0);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 4);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(3).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth() == 2);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 3);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 0);
+
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
 	}
 	
 	
 	@Test
 	public void test4() throws HSException {
 
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
 
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getTotalHealth() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
 		
-		board.data_.placeCard_hand_p0(new HolySmite());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 2);
-		ret = theCard.useOn(1, target, board, deck, null);
-		
-		assertFalse(ret == null);
-		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		
-		assertTrue(board.data_.getMinion_p0(0).getTotalHealth() == 6);
-		assertTrue(board.data_.getMinion_p0(1).getTotalHealth() == 1);
-		assertTrue(board.data_.getMinion_p0(2).getTotalHealth() == 3);
-		assertTrue(board.data_.getMinion_p1(0).getTotalHealth() == 2);
-		assertTrue(board.data_.getMinion_p1(1).getTotalHealth() == 2);
-		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
-		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
-
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
-		
-		
-		board.data_.placeCard_hand_p0(new Silence());
-		theCard = board.data_.getCard_hand_p0(0);
-		target = board.data_.getCharacter(0, 1);
-		ret = theCard.useOn(0, target, board, deck, null);
+		board.data_.placeCardHandCurrentPlayer(new HolySmite());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 3);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 6);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 2);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
 		
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 4);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth() == 6);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth() == 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth() == 2);
 		
-		assertEquals(board.data_.getMinion_p0(0).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraAttack(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getAuraAttack(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
 
-		assertEquals(board.data_.getMinion_p0(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(1).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p0(2).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(0).getAuraHealth(), 0);
-		assertEquals(board.data_.getMinion_p1(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
+		
+		
+		board.data_.placeCardHandCurrentPlayer(new Silence());
+		theCard = board.data_.getCurrentPlayerCardHand(0);
+		target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
+		
+		assertFalse(ret == null);
+		assertTrue(board.data_.getNumCards_hand() == 0);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 3);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 2);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 4);
+		
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraAttack(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraAttack(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraAttack(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraAttack(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraAttack(), 1);
+
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getAuraHealth(), 0);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getAuraHealth(), 0);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getAuraHealth(), 0);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestStranglethornTiger.java
+++ b/src/test/java/com/hearthsim/test/minion/TestStranglethornTiger.java
@@ -32,10 +32,10 @@ public class TestStranglethornTiger {
 		Minion minion0_1 = new BoulderfistOgre();
 		Minion minion1_1 = new StranglethornTiger();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -52,15 +52,15 @@ public class TestStranglethornTiger {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -76,19 +76,19 @@ public class TestStranglethornTiger {
 	public void test0() throws HSException {
 		
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 5);
 	}
 	
 	
@@ -104,21 +104,21 @@ public class TestStranglethornTiger {
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 
-		assertEquals(resBoard.getNumCards_hand_p0(), 0);
-		assertEquals(resBoard.getNumCards_hand_p1(), 0);
-		assertEquals(resBoard.getNumMinions_p0(), 2);
-		assertEquals(resBoard.getNumMinions_p1(), 1);
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 0);
+		assertEquals(resBoard.getNumCardsHandWaitingPlayer(), 0);
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(resBoard.getMana_p0(), 8);
 		assertEquals(resBoard.getMana_p1(), 8);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 18);
-		assertEquals(resBoard.getMinion_p0(0).getTotalHealth(), 7);
-		assertEquals(resBoard.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(resBoard.getMinion_p1(0).getTotalHealth(), 5);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 18);
+		assertEquals(resBoard.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 7);
+		assertEquals(resBoard.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(resBoard.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 5);
 
-		assertEquals(resBoard.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(resBoard.getMinion_p0(1).getTotalAttack(), 6);
-		assertEquals(resBoard.getMinion_p1(0).getTotalAttack(), 5);
+		assertEquals(resBoard.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(resBoard.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 6);
+		assertEquals(resBoard.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 5);
 	}
 	
 	@Test
@@ -131,26 +131,26 @@ public class TestStranglethornTiger {
 		PlayerModel playerModel0 = new PlayerModel("player0", hero, deck);
 		PlayerModel playerModel1 = new PlayerModel("player0", hero, deck);
 		
-		board.data_.placeCard_hand_p0(new Silence());
+		board.data_.placeCardHandCurrentPlayer(new Silence());
 
         ArtificialPlayer ai0 = ArtificialPlayer.buildStandardAI1();
 		BoardModel resBoard = ai0.playTurn(0, board.data_, playerModel0, playerModel1);
 
-		assertEquals(resBoard.getNumCards_hand_p0(), 1);
-		assertEquals(resBoard.getNumCards_hand_p1(), 0);
-		assertEquals(resBoard.getNumMinions_p0(), 2);
-		assertEquals(resBoard.getNumMinions_p1(), 1);
+		assertEquals(resBoard.getNumCardsHandCurrentPlayer(), 1);
+		assertEquals(resBoard.getNumCardsHandWaitingPlayer(), 0);
+		assertEquals(resBoard.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(resBoard.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(resBoard.getMana_p0(), 8);
 		assertEquals(resBoard.getMana_p1(), 8);
-		assertEquals(resBoard.getHero_p0().getHealth(), 30);
-		assertEquals(resBoard.getHero_p1().getHealth(), 18);
-		assertEquals(resBoard.getMinion_p0(0).getTotalHealth(), 7);
-		assertEquals(resBoard.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(resBoard.getMinion_p1(0).getTotalHealth(), 5);
+		assertEquals(resBoard.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(resBoard.getWaitingPlayerHero().getHealth(), 18);
+		assertEquals(resBoard.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 7);
+		assertEquals(resBoard.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(resBoard.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 5);
 
-		assertEquals(resBoard.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(resBoard.getMinion_p0(1).getTotalAttack(), 6);
-		assertEquals(resBoard.getMinion_p1(0).getTotalAttack(), 5);
+		assertEquals(resBoard.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(resBoard.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 6);
+		assertEquals(resBoard.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 5);
 	}
 	
 	@Test
@@ -168,18 +168,18 @@ public class TestStranglethornTiger {
 		BoardModel resBoard0 = ai0.playTurn(0, board.data_.flipPlayers(), playerModel1, playerModel0, 2000000000);
 		BoardModel resBoard1 = ai0.playTurn(0, resBoard0.flipPlayers(), playerModel0, playerModel1, 2000000000);
 
-		assertEquals(resBoard1.getNumCards_hand_p1(), 0);
-		assertEquals(resBoard1.getNumCards_hand_p1(), 0);
-		assertEquals(resBoard1.getNumMinions_p0(), 2);
-		assertEquals(resBoard1.getNumMinions_p1(), 0);
+		assertEquals(resBoard1.getNumCardsHandWaitingPlayer(), 0);
+		assertEquals(resBoard1.getNumCardsHandWaitingPlayer(), 0);
+		assertEquals(resBoard1.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(resBoard1.getWaitingPlayer().getNumMinions(), 0);
 		assertEquals(resBoard1.getMana_p0(), 8);
 		assertEquals(resBoard1.getMana_p1(), 8);
-		assertEquals(resBoard1.getHero_p0().getHealth(), 25);
-		assertEquals(resBoard1.getHero_p1().getHealth(), 24);
-		assertEquals(resBoard1.getMinion_p0(0).getTotalHealth(), 7);
-		assertEquals(resBoard1.getMinion_p0(1).getTotalHealth(), 2);
+		assertEquals(resBoard1.getCurrentPlayerHero().getHealth(), 25);
+		assertEquals(resBoard1.getWaitingPlayerHero().getHealth(), 24);
+		assertEquals(resBoard1.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 7);
+		assertEquals(resBoard1.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 2);
 
-		assertEquals(resBoard1.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(resBoard1.getMinion_p0(1).getTotalAttack(), 6);
+		assertEquals(resBoard1.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(resBoard1.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 6);
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestUnstableGhoul.java
+++ b/src/test/java/com/hearthsim/test/minion/TestUnstableGhoul.java
@@ -31,12 +31,12 @@ public class TestUnstableGhoul {
 		Minion minion1_1 = new RaidLeader();
 		Minion minion1_2 = new ScarletCrusader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
-		board.data_.placeCard_hand_p1(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,7 +46,7 @@ public class TestUnstableGhoul {
 		deck = new Deck(cards);
 
 		Card fb = new UnstableGhoul();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -56,17 +56,17 @@ public class TestUnstableGhoul {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -80,126 +80,126 @@ public class TestUnstableGhoul {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 		
 		//attack the Ogre... deal 1 damage to all
-		target = board.data_.getCharacter(1, 3);
-		Minion attacker = board.data_.getCharacter(0, 1);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		Minion attacker = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
 		attacker.hasAttacked(false);
-		ret = attacker.attack(1, target, ret, null, null);
+		ret = attacker.attack(ret.data_.getWaitingPlayer(), target, ret, null, null);
 
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 4);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 4);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertFalse(board.data_.getMinion_p1(0).getDivineShield());
+		assertFalse(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 
 	}
 	
@@ -207,61 +207,61 @@ public class TestUnstableGhoul {
 	public void test3() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 3);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 		
 		//Silence the Unstable Ghoul first, then attack with it
-		target = board.data_.getCharacter(1, 3);
-		Minion attacker = board.data_.getCharacter(0, 1);
-		attacker.silenced(0, board, null, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		Minion attacker = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		attacker.silenced(board.data_.getCurrentPlayer(), board, null, null);
 		attacker.hasAttacked(false);
-		ret = attacker.attack(1, target, ret, null, null);
+		ret = attacker.attack(ret.data_.getWaitingPlayer(), target, ret, null, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 6);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 5);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(0).getDivineShield());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getDivineShield());
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/minion/TestVioletTeacher.java
+++ b/src/test/java/com/hearthsim/test/minion/TestVioletTeacher.java
@@ -30,11 +30,11 @@ public class TestVioletTeacher {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestVioletTeacher {
 		deck = new Deck(cards);
 
 		Card fb = new VioletTeacher();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -54,16 +54,16 @@ public class TestVioletTeacher {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -79,112 +79,112 @@ public class TestVioletTeacher {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test1() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 5);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		
 		//----------------------------------------------------------
 		// Use a spell now... p0 should get a Violet Apprentice
 		Card cardToUse = new HolySmite();
-		board.data_.placeCard_hand_p0(cardToUse);
-		target = board.data_.getCharacter(1, 1);
-		ret = cardToUse.useOn(1, target, ret, deck, null);
+		board.data_.placeCardHandCurrentPlayer(cardToUse);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = cardToUse.useOn(ret.data_.getWaitingPlayer(), target, ret, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 4);
-		assertEquals(board.data_.getNumMinions_p1(), 1);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 1);
 		assertEquals(board.data_.getMana_p0(), 3);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 5);
-		assertEquals(board.data_.getMinion_p0(3).getHealth(), 1);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 5);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getHealth(), 1);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p0(3).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 6);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(3).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
 		
 		//----------------------------------------------------------
 		// flipped, p1 should not get a Violet Apprentice
 		HearthTreeNode flp = new HearthTreeNode(board.data_.flipPlayers());
 		Card cardToUse2 = new HolySmite();
-		flp.data_.placeCard_hand_p0(cardToUse2);
+		flp.data_.placeCardHandCurrentPlayer(cardToUse2);
 
 		assertEquals(flp.data_.getNumCards_hand(), 1);
 
-		target = flp.data_.getCharacter(1, 1);
-		ret = cardToUse2.useOn(1, target, flp, deck, null);
+		target = flp.data_.getCharacter(flp.data_.getWaitingPlayer(), 1);
+		ret = cardToUse2.useOn(flp.data_.getWaitingPlayer(), target, flp, deck, null);
 
 		assertEquals(ret.data_.getNumCards_hand(), 0);
-		assertEquals(ret.data_.getNumMinions_p0(), 1);
-		assertEquals(ret.data_.getNumMinions_p1(), 3);
+		assertEquals(ret.data_.getCurrentPlayer().getNumMinions(), 1);
+		assertEquals(ret.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(ret.data_.getMana_p0(), 7);
 		assertEquals(ret.data_.getMana_p1(), 3);
-		assertEquals(ret.data_.getHero_p0().getHealth(), 30);
-		assertEquals(ret.data_.getHero_p1().getHealth(), 30);
-		assertEquals(ret.data_.getMinion_p0(0).getHealth(), 7);
-		assertEquals(ret.data_.getMinion_p1(0).getHealth(), 7);
-		assertEquals(ret.data_.getMinion_p1(1).getHealth(), 5);
-		assertEquals(ret.data_.getMinion_p1(2).getHealth(), 1);
+		assertEquals(ret.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 7);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 5);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getHealth(), 1);
 
-		assertEquals(ret.data_.getMinion_p0(0).getTotalAttack(), 6);
-		assertEquals(ret.data_.getMinion_p1(0).getTotalAttack(), 6);
-		assertEquals(ret.data_.getMinion_p1(1).getTotalAttack(), 3);
-		assertEquals(ret.data_.getMinion_p1(2).getTotalAttack(), 1);
+		assertEquals(ret.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 6);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 3);
+		assertEquals(ret.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 1);
 		
 	}
 

--- a/src/test/java/com/hearthsim/test/minion/TestWaterElemental.java
+++ b/src/test/java/com/hearthsim/test/minion/TestWaterElemental.java
@@ -30,11 +30,11 @@ public class TestWaterElemental {
 		Minion minion1_0 = new BoulderfistOgre();
 		Minion minion1_1 = new RaidLeader();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -44,7 +44,7 @@ public class TestWaterElemental {
 		deck = new Deck(cards);
 
 		Card fb = new WaterElemental();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -54,16 +54,16 @@ public class TestWaterElemental {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -79,86 +79,86 @@ public class TestWaterElemental {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getHealth(), 6);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getHealth(), 6);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 4);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 4);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 		
 		
 		//----------------------------------------------------------
 		
-		Minion waterElemental = board.data_.getMinion_p0(2);
+		Minion waterElemental = board.data_.getCurrentPlayer().getMinions().get(2);
 		assertTrue(waterElemental instanceof WaterElemental);
 		
 		waterElemental.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		waterElemental.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		waterElemental.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 4);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getHealth(), 7 - 4);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getHealth(), 7 - 4);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
-		assertTrue(board.data_.getMinion_p1(1).getFrozen());
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getFrozen());
 		
 	}
 	

--- a/src/test/java/com/hearthsim/test/minion/TestZombieChow.java
+++ b/src/test/java/com/hearthsim/test/minion/TestZombieChow.java
@@ -30,12 +30,12 @@ public class TestZombieChow {
 		Minion minion1_1 = new RaidLeader();
 		Minion minion1_2 = new ZombieChow();
 		
-		board.data_.placeCard_hand_p0(minion0_0);
-		board.data_.placeCard_hand_p0(minion0_1);
+		board.data_.placeCardHandCurrentPlayer(minion0_0);
+		board.data_.placeCardHandCurrentPlayer(minion0_1);
 				
-		board.data_.placeCard_hand_p1(minion1_2);
-		board.data_.placeCard_hand_p1(minion1_0);
-		board.data_.placeCard_hand_p1(minion1_1);
+		board.data_.placeCardHandWaitingPlayer(minion1_2);
+		board.data_.placeCardHandWaitingPlayer(minion1_0);
+		board.data_.placeCardHandWaitingPlayer(minion1_1);
 
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -45,7 +45,7 @@ public class TestZombieChow {
 		deck = new Deck(cards);
 
 		Card fb = new ZombieChow();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 		board.data_.setMana_p0((byte)8);
 		board.data_.setMana_p1((byte)8);
@@ -55,17 +55,17 @@ public class TestZombieChow {
 		
 		HearthTreeNode tmpBoard = new HearthTreeNode(board.data_.flipPlayers());
 		try {
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
-			tmpBoard.data_.getCard_hand_p0(0).useOn(0, tmpBoard.data_.getHero_p0(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
+			tmpBoard.data_.getCurrentPlayerCardHand(0).useOn(tmpBoard.data_.getCurrentPlayer(), tmpBoard.data_.getCurrentPlayerHero(), tmpBoard, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		board = new HearthTreeNode(tmpBoard.data_.flipPlayers());
 		try {
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
-			board.data_.getCard_hand_p0(0).useOn(0, board.data_.getHero_p0(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
+			board.data_.getCurrentPlayerCardHand(0).useOn(board.data_.getCurrentPlayer(), board.data_.getCurrentPlayerHero(), board, deck, null);
 		} catch (HSException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -81,118 +81,118 @@ public class TestZombieChow {
 	public void test0() throws HSException {
 		
 		//null case
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 1);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 8);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 30);
-		assertEquals(board.data_.getHero_p1().getHealth(), 30);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 30);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 3);
 	}
 	
 	@Test
 	public void test2() throws HSException {
 
 		//Heroes are already damaged
-		board.data_.getHero_p0().setHealth((byte)15);
-		board.data_.getHero_p1().setHealth((byte)15);
+		board.data_.getCurrentPlayerHero().setHealth((byte)15);
+		board.data_.getWaitingPlayerHero().setHealth((byte)15);
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 15);
-		assertEquals(board.data_.getHero_p1().getHealth(), 15);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 15);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 15);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 3);
 
 		
 		
 		//----------------------------------------------------------
 		
-		Minion minion = board.data_.getMinion_p0(2);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(2);
 		assertTrue(minion instanceof ZombieChow);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 2);
-		minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 2);
+		minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 15);
-		assertEquals(board.data_.getHero_p1().getHealth(), 20);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7 - 3);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 15);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 20);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7 - 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 3);
 
 		//----------------------------------------------------------
 		
-		minion = board.data_.getMinion_p0(1);
+		minion = board.data_.getCurrentPlayer().getMinions().get(1);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 3);
-		minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 20);
-		assertEquals(board.data_.getHero_p1().getHealth(), 20);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7 - 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7 - 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 20);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 20);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7 - 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7 - 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 		
 	}
 
@@ -200,61 +200,61 @@ public class TestZombieChow {
 	public void test3() throws HSException {
 
 		//Heroes are already damaged
-		board.data_.getHero_p0().setHealth((byte)15);
-		board.data_.getHero_p1().setHealth((byte)15);
+		board.data_.getCurrentPlayerHero().setHealth((byte)15);
+		board.data_.getWaitingPlayerHero().setHealth((byte)15);
 		
-		Minion target = board.data_.getCharacter(0, 2);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 2);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 3);
-		assertEquals(board.data_.getNumMinions_p1(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 3);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 15);
-		assertEquals(board.data_.getHero_p1().getHealth(), 15);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalHealth(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalHealth(), 3);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 15);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 15);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalHealth(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalHealth(), 3);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p0(2).getTotalAttack(), 3);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(2).getTotalAttack(), 3);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(2).getTotalAttack(), 3);
 
 		
 		
 		//----------------------------------------------------------
 		
-		Minion minion = board.data_.getMinion_p0(2);
+		Minion minion = board.data_.getCurrentPlayer().getMinions().get(2);
 		assertTrue(minion instanceof ZombieChow);
 		
 		minion.hasAttacked(false);
-		target = board.data_.getCharacter(1, 3);
-		minion.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 3);
+		minion.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 
 		assertEquals(board.data_.getNumCards_hand(), 0);
-		assertEquals(board.data_.getNumMinions_p0(), 2);
-		assertEquals(board.data_.getNumMinions_p1(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getNumMinions(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getNumMinions(), 2);
 		assertEquals(board.data_.getMana_p0(), 7);
 		assertEquals(board.data_.getMana_p1(), 8);
-		assertEquals(board.data_.getHero_p0().getHealth(), 20);
-		assertEquals(board.data_.getHero_p1().getHealth(), 20);
-		assertEquals(board.data_.getMinion_p0(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalHealth(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalHealth(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getCurrentPlayerHero().getHealth(), 20);
+		assertEquals(board.data_.getWaitingPlayerHero().getHealth(), 20);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalHealth(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalHealth(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalHealth(), 7);
 
-		assertEquals(board.data_.getMinion_p0(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p0(1).getTotalAttack(), 7);
-		assertEquals(board.data_.getMinion_p1(0).getTotalAttack(), 2);
-		assertEquals(board.data_.getMinion_p1(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getCurrentPlayer().getMinions().get(1).getTotalAttack(), 7);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(0).getTotalAttack(), 2);
+		assertEquals(board.data_.getWaitingPlayer().getMinions().get(1).getTotalAttack(), 7);
 	}
 }

--- a/src/test/java/com/hearthsim/test/testBoardState.java
+++ b/src/test/java/com/hearthsim/test/testBoardState.java
@@ -44,34 +44,34 @@ public class testBoardState {
 		
 		assertTrue(board1.equals(board2));
 		
-		board1.placeCard_hand_p0(cards1[0]);
-		board3.placeCard_hand_p0(cards3[0]);
+		board1.placeCardHandCurrentPlayer(cards1[0]);
+		board3.placeCardHandCurrentPlayer(cards3[0]);
 
 		assertFalse(board1.equals(board2));
 		assertTrue(board1.equals(board3));
 		
-		board2.placeCard_hand_p0(cards3[0]);
+		board2.placeCardHandCurrentPlayer(cards3[0]);
 		assertTrue(board1.equals(board2));
 		
-		board1.placeCard_hand_p0(cards1[1]);
-		board3.placeCard_hand_p0(cards3[1]);
-		board2.placeCard_hand_p0(cards2[1]);
+		board1.placeCardHandCurrentPlayer(cards1[1]);
+		board3.placeCardHandCurrentPlayer(cards3[1]);
+		board2.placeCardHandCurrentPlayer(cards2[1]);
 		assertFalse(board1.equals(board2));
 		assertTrue(board1.equals(board3));
 		
-		board1.placeMinion(0, (Minion)cards1[2]);
-		board2.placeMinion(0, (Minion)cards2[2]);
-		board2.placeMinion(0, (Minion)cards2[3]);
-		board3.placeMinion(0, (Minion)cards3[2]);
+		board1.placeMinion(board1.getCurrentPlayer(), (Minion)cards1[2]);
+		board2.placeMinion(board2.getCurrentPlayer(), (Minion)cards2[2]);
+		board2.placeMinion(board2.getCurrentPlayer(), (Minion)cards2[3]);
+		board3.placeMinion(board3.getCurrentPlayer(), (Minion)cards3[2]);
 
 
 		assertTrue(board1.equals(board3));
 		assertFalse(board1.equals(board2));
 
-		board1.placeMinion(1, (Minion)cards1[4]);
-		board1.placeMinion(1, (Minion)cards1[5]);
-		board3.placeMinion(1, (Minion)cards3[4]);
-		board3.placeMinion(1, (Minion)cards3[5]);
+		board1.placeMinion(board1.getWaitingPlayer(), (Minion)cards1[4]);
+		board1.placeMinion(board1.getWaitingPlayer(), (Minion)cards1[5]);
+		board3.placeMinion(board3.getWaitingPlayer(), (Minion)cards3[4]);
+		board3.placeMinion(board3.getWaitingPlayer(), (Minion)cards3[5]);
 		assertTrue(board1.equals(board3));
 
 		
@@ -126,15 +126,15 @@ public class testBoardState {
 			int nm2 = (int)(Math.random() * 2) + 1;
 			
 			for (int j = 0; j < nh; ++j) {
-				boards[i].placeCard_hand_p0(cards1[(int)(Math.random() * numCards1)]);
+				boards[i].placeCardHandCurrentPlayer(cards1[(int) (Math.random() * numCards1)]);
 			}
 
 			for (int j = 0; j < nm1; ++j) {
-				boards[i].placeMinion(0, (Minion)cards2[(int)(Math.random() * numCards2)]);
+				boards[i].placeMinion(boards[i].getCurrentPlayer(), (Minion)cards2[(int)(Math.random() * numCards2)]);
 			}
 
 			for (int j = 0; j < nm2; ++j) {
-				boards[i].placeMinion(1, (Minion)cards3[(int)(Math.random() * numCards3)]);
+				boards[i].placeMinion(boards[i].getWaitingPlayer(), (Minion)cards3[(int)(Math.random() * numCards3)]);
 			}
 		}
 		

--- a/src/test/java/com/hearthsim/test/weapon/TestFieryWarAxe.java
+++ b/src/test/java/com/hearthsim/test/weapon/TestFieryWarAxe.java
@@ -32,11 +32,11 @@ public class TestFieryWarAxe {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -46,107 +46,107 @@ public class TestFieryWarAxe {
 		deck = new Deck(cards);
 
 		FieryWarAxe fb = new FieryWarAxe();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 	}
 
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getHero_p0().getAttack() == 3);
-		assertTrue(board.data_.getHero_p0().getWeaponCharge() == 2);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayerHero().getAttack() == 3);
+		assertTrue(board.data_.getCurrentPlayerHero().getWeaponCharge() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
 		
 		
-		Minion hero = ret.data_.getHero_p0();
-		target = board.data_.getCharacter(1, 0);
-		ret = hero.attack(1, target, ret, deck, null);
+		Minion hero = ret.data_.getCurrentPlayerHero();
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		ret = hero.attack(ret.data_.getWaitingPlayer(), target, ret, deck, null);
 
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 27);
-		assertTrue(board.data_.getHero_p0().getAttack() == 3);
-		assertTrue(board.data_.getHero_p0().getWeaponCharge() == 1);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 27);
+		assertTrue(board.data_.getCurrentPlayerHero().getAttack() == 3);
+		assertTrue(board.data_.getCurrentPlayerHero().getWeaponCharge() == 1);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
-		target = board.data_.getCharacter(1, 1);
-		ret = hero.attack(1, target, ret, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = hero.attack(ret.data_.getWaitingPlayer(), target, ret, deck, null);
 		assertTrue(ret == null);
 		
 		
 		hero.hasAttacked(false);
-		target = board.data_.getCharacter(1, 1);
-		ret = hero.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = hero.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 1);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30 - attack0);
-		assertTrue(board.data_.getHero_p1().getHealth() == 27);
-		assertTrue(board.data_.getHero_p0().getAttack() == 0);
-		assertTrue(board.data_.getHero_p0().getWeaponCharge() == 0);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 1);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30 - attack0);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 27);
+		assertTrue(board.data_.getCurrentPlayerHero().getAttack() == 0);
+		assertTrue(board.data_.getCurrentPlayerHero().getWeaponCharge() == 0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health1 - 1);
 
 	}
 }

--- a/src/test/java/com/hearthsim/test/weapon/TestLightsJustice.java
+++ b/src/test/java/com/hearthsim/test/weapon/TestLightsJustice.java
@@ -33,11 +33,11 @@ public class TestLightsJustice {
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion1_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		
-		board.data_.placeMinion(0, minion0_0);
-		board.data_.placeMinion(0, minion0_1);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_0);
+		board.data_.placeMinion(board.data_.getCurrentPlayer(), minion0_1);
 		
-		board.data_.placeMinion(1, minion1_0);
-		board.data_.placeMinion(1, minion1_1);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_0);
+		board.data_.placeMinion(board.data_.getWaitingPlayer(), minion1_1);
 		
 		Card cards[] = new Card[10];
 		for (int index = 0; index < 10; ++index) {
@@ -47,108 +47,108 @@ public class TestLightsJustice {
 		deck = new Deck(cards);
 
 		LightsJustice fb = new LightsJustice();
-		board.data_.placeCard_hand_p0(fb);
+		board.data_.placeCardHandCurrentPlayer(fb);
 
 	}
 	
 	@Test
 	public void test0() throws HSException {
 		
-		Minion target = board.data_.getCharacter(1, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(1, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getWaitingPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 	}
 
 
 	@Test
 	public void test1() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 1);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 1);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertTrue(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 1);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 	}
 
 	@Test
 	public void test2() throws HSException {
 		
-		Minion target = board.data_.getCharacter(0, 0);
-		Card theCard = board.data_.getCard_hand_p0(0);
-		HearthTreeNode ret = theCard.useOn(0, target, board, deck, null);
+		Minion target = board.data_.getCharacter(board.data_.getCurrentPlayer(), 0);
+		Card theCard = board.data_.getCurrentPlayerCardHand(0);
+		HearthTreeNode ret = theCard.useOn(board.data_.getCurrentPlayer(), target, board, deck, null);
 		
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 30);
-		assertTrue(board.data_.getHero_p0().getAttack() == 1);
-		assertTrue(board.data_.getHero_p0().getWeaponCharge() == 4);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getCurrentPlayerHero().getAttack() == 1);
+		assertTrue(board.data_.getCurrentPlayerHero().getWeaponCharge() == 4);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
 		
 		
-		Minion hero = ret.data_.getHero_p0();
-		target = board.data_.getCharacter(1, 0);
-		ret = hero.attack(1, target, ret, deck, null);
+		Minion hero = ret.data_.getCurrentPlayerHero();
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 0);
+		ret = hero.attack(ret.data_.getWaitingPlayer(), target, ret, deck, null);
 
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30);
-		assertTrue(board.data_.getHero_p1().getHealth() == 29);
-		assertTrue(board.data_.getHero_p0().getAttack() == 1);
-		assertTrue(board.data_.getHero_p0().getWeaponCharge() == 3);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 29);
+		assertTrue(board.data_.getCurrentPlayerHero().getAttack() == 1);
+		assertTrue(board.data_.getCurrentPlayerHero().getWeaponCharge() == 3);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 		
-		target = board.data_.getCharacter(1, 1);
-		ret = hero.attack(1, target, ret, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = hero.attack(ret.data_.getWaitingPlayer(), target, ret, deck, null);
 		assertTrue(ret == null);
 		
 		
 		hero.hasAttacked(false);
-		target = board.data_.getCharacter(1, 1);
-		ret = hero.attack(1, target, board, deck, null);
+		target = board.data_.getCharacter(board.data_.getWaitingPlayer(), 1);
+		ret = hero.attack(board.data_.getWaitingPlayer(), target, board, deck, null);
 		assertFalse(ret == null);
 		assertTrue(board.data_.getNumCards_hand() == 0);
-		assertTrue(board.data_.getNumMinions_p0() == 2);
-		assertTrue(board.data_.getNumMinions_p1() == 2);
-		assertTrue(board.data_.getHero_p0().getHealth() == 30 - attack0);
-		assertTrue(board.data_.getHero_p1().getHealth() == 29);
-		assertTrue(board.data_.getHero_p0().getAttack() == 1);
-		assertTrue(board.data_.getHero_p0().getWeaponCharge() == 2);
-		assertTrue(board.data_.getMinion_p0(0).getHealth() == health0);
-		assertTrue(board.data_.getMinion_p0(1).getHealth() == health1 - 1);
-		assertTrue(board.data_.getMinion_p1(0).getHealth() == health0 - 1);
-		assertTrue(board.data_.getMinion_p1(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getCurrentPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getWaitingPlayer().getNumMinions() == 2);
+		assertTrue(board.data_.getCurrentPlayerHero().getHealth() == 30 - attack0);
+		assertTrue(board.data_.getWaitingPlayerHero().getHealth() == 29);
+		assertTrue(board.data_.getCurrentPlayerHero().getAttack() == 1);
+		assertTrue(board.data_.getCurrentPlayerHero().getWeaponCharge() == 2);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(0).getHealth() == health0);
+		assertTrue(board.data_.getCurrentPlayer().getMinions().get(1).getHealth() == health1 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(0).getHealth() == health0 - 1);
+		assertTrue(board.data_.getWaitingPlayer().getMinions().get(1).getHealth() == health1 - 1);
 
 	}
 }


### PR DESCRIPTION
This isn't ready for merge!
I just wanted to put this up there to show the massive refactoring I'm working on. In this state all the tests are passing, but I'm not happy about lines like:

record.put(turnCount + 1, boardModel_.getCurrentPlayer(), (BoardModel) boardModel_.deepCopy());

Basically, I replaced all the 0/1 indexing with references to the current or waiting player. It's too unwieldily though, so what I'm aiming to do is replace all of those with a simple ENUM, player status (WAITING/CURRENT). Now that it's in this state with all tests passing that next refactoring should be simpler, mostly searching and replacing all getCurrentPlayer()/getWaitingPlayer() calls with the enums and refactoring method signatures. 

Hopefully there are no other big refactorings going on in parallel!
