### PR TITLE
initial spock tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ apply plugin: 'idea'
 apply plugin: 'jacoco'
 apply plugin: 'checkstyle'
 apply plugin: 'pmd'
+apply plugin: "groovy"
+
 
 task(runGui, dependsOn: 'classes', type: JavaExec) {
     main = 'com.hearthsim.gui.HearthSim'
@@ -18,15 +20,15 @@ task(runSim, dependsOn: 'classes', type: JavaExec) {
 
 repositories {
     jcenter()
+    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
 dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.2'
-
-    compile 'org.codehaus.groovy:groovy-all:2.3.3'
-
+    compile 'org.codehaus.groovy:groovy-all:2.3.6'
     compile 'org.apache.commons:commons-math3:3.3'
     compile 'org.json:json:20140107'
 
     testCompile 'junit:junit:4.11'
+    testCompile "org.spockframework:spock-core:1.0-groovy-2.3-SNAPSHOT"
 }

--- a/src/main/java/com/hearthsim/card/minion/concrete/Succubus.java
+++ b/src/main/java/com/hearthsim/card/minion/concrete/Succubus.java
@@ -187,7 +187,7 @@ public class Succubus extends Demon {
 		if (numCards <= 0)
 			return null;
 		int cardToDiscardIndex = (int)(Math.random() * numCards);
-		toRet.data_.removeCard_hand(PlayerSide.CURRENT_PLAYER.getPlayer(toRet).getMinions().get(cardToDiscardIndex));
+		toRet.data_.removeCardFromHand(PlayerSide.CURRENT_PLAYER.getPlayer(toRet).getMinions().get(cardToDiscardIndex), PlayerSide.CURRENT_PLAYER);
 							
 		return boardState;
 	}

--- a/src/main/java/com/hearthsim/model/BoardModel.java
+++ b/src/main/java/com/hearthsim/model/BoardModel.java
@@ -244,6 +244,14 @@ public class BoardModel implements DeepCopyable {
         currentPlayer.getHand().remove(card);
     }
 
+    public void placeCardHand(PlayerSide side, Card card){
+        modelForSide(side).placeCardHand(card);
+    }
+
+    public void removeCardFromHand(Card card, PlayerSide playerSide){
+        modelForSide(playerSide).getHand().remove(card);
+    }
+
     public int getNumCards_hand() {
         return currentPlayer.getHand().size();
     }
@@ -270,6 +278,22 @@ public class BoardModel implements DeepCopyable {
 
     public Hero getWaitingPlayerHero() {
         return waitingPlayer.getHero();
+    }
+
+    public void setFatigueDamage(PlayerSide playerSide, byte fatigueDamage) {
+        if (playerSide == PlayerSide.CURRENT_PLAYER){
+            p0_fatigueDamage_= fatigueDamage;
+        }else{
+            p1_fatigueDamage_= fatigueDamage;
+        }
+    }
+
+    public int getFatigueDamage(PlayerSide playerSide){
+        if (playerSide==PlayerSide.CURRENT_PLAYER){
+            return p0_fatigueDamage_;
+        }else{
+            return p1_fatigueDamage_;
+        }
     }
 
     /**

--- a/src/main/java/com/hearthsim/util/DeepCopyable.java
+++ b/src/main/java/com/hearthsim/util/DeepCopyable.java
@@ -1,5 +1,5 @@
 package com.hearthsim.util;
 
-public interface DeepCopyable {
-	public Object deepCopy();
+public interface DeepCopyable<T> {
+	public T deepCopy();
 }

--- a/src/test/groovy/com/hearthsim/test/HearthBaseSpec.groovy
+++ b/src/test/groovy/com/hearthsim/test/HearthBaseSpec.groovy
@@ -1,0 +1,16 @@
+package com.hearthsim.test
+
+import spock.lang.Specification
+
+import static org.hamcrest.CoreMatchers.notNullValue
+import static spock.util.matcher.HamcrestSupport.that
+
+abstract class HearthBaseSpec extends Specification{
+
+    def assertCardInHand(Class cardClass, List hand){
+        def foundCard = hand.find { it.class == cardClass }
+        assert that(foundCard, notNullValue())
+    }
+
+
+}

--- a/src/test/groovy/com/hearthsim/test/IsByteEqual.groovy
+++ b/src/test/groovy/com/hearthsim/test/IsByteEqual.groovy
@@ -1,0 +1,29 @@
+package com.hearthsim.test
+
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+
+class IsByteEqual<Number> extends BaseMatcher<Number> {
+
+    private final Byte object;
+
+    public IsByteEqual(Number object) {
+        this.object = (byte) object;
+    }
+
+    @Override
+    boolean matches(Object arg) {
+        return arg == object;
+    }
+
+    @Override
+    void describeTo(Description description) {
+        description.appendText("equal after byte cast")
+    }
+
+    @org.hamcrest.Factory
+    public static <T> Matcher<T> isByteEqual(T target) {
+        return new IsByteEqual<T>(target);
+    }
+}

--- a/src/test/groovy/com/hearthsim/test/groovy/card/CardSpec.groovy
+++ b/src/test/groovy/com/hearthsim/test/groovy/card/CardSpec.groovy
@@ -1,0 +1,15 @@
+package com.hearthsim.test.groovy.card
+
+import com.hearthsim.model.BoardModel
+import com.hearthsim.test.helpers.BoardModelBuilder
+import org.junit.Assert
+import spock.lang.Specification
+
+class CardSpec extends Specification{
+
+    void assertBoardDelta(BoardModel oldBoard, BoardModel newBoard, Closure deltaClosure) {
+        def oldBoardCopy = oldBoard.deepCopy()
+        def expectedBoard = new BoardModelBuilder(boardModel: oldBoardCopy).make(deltaClosure)
+        Assert.assertEquals(expectedBoard, newBoard)
+    }
+}

--- a/src/test/groovy/com/hearthsim/test/groovy/card/ElvenArcherSpec.groovy
+++ b/src/test/groovy/com/hearthsim/test/groovy/card/ElvenArcherSpec.groovy
@@ -1,0 +1,137 @@
+package com.hearthsim.test.groovy.card
+
+import com.hearthsim.card.minion.concrete.Abomination
+import com.hearthsim.card.minion.concrete.ElvenArcher
+import com.hearthsim.model.BoardModel
+import com.hearthsim.test.helpers.BoardModelBuilder
+import com.hearthsim.util.tree.HearthTreeNode
+import spock.lang.Specification
+
+import static com.hearthsim.model.PlayerSide.CURRENT_PLAYER
+import static com.hearthsim.model.PlayerSide.WAITING_PLAYER
+import static org.junit.Assert.*
+
+class ElvenArcherSpec extends CardSpec {
+
+    HearthTreeNode root
+    BoardModel startingBoard
+
+    def setup() {
+
+        def minionMana = 2;
+        def attack = 5;
+        def health0 = 3;
+        def health1 = 7;
+
+        def commonField = [
+                [mana: minionMana, attack: attack, maxHealth: health0], //todo: attack may be irrelevant here
+                [mana: minionMana, attack: attack, health: health1 - 1, maxHealth: health1]
+        ]
+
+        startingBoard = new BoardModelBuilder().make {
+            currentPlayer {
+                hand([ElvenArcher])
+                field(commonField)
+                mana(7)
+            }
+            waitingPlayer {
+                field(commonField + [minion: Abomination, health: 1])
+                mana(4)
+            }
+        }
+
+        root = new HearthTreeNode(startingBoard)
+    }
+
+
+    def "cannot play for waiting player's side"() {
+        def copiedBoard = startingBoard.deepCopy()
+        def target = copiedBoard.getCharacter(WAITING_PLAYER, 0)
+        def theCard = copiedBoard.getCurrentPlayerCardHand(0)
+        def ret = theCard.useOn(WAITING_PLAYER, target, root, null, null)
+
+        expect:
+
+        assertTrue(ret == null)
+        assertEquals(copiedBoard, startingBoard)
+    }
+
+    def "playing for current player returns expected child states"() {
+        def minionPlayedBoard = startingBoard.deepCopy()
+        def copiedRoot = new HearthTreeNode(minionPlayedBoard)
+        def target = minionPlayedBoard.getCharacter(CURRENT_PLAYER, 2);
+        def theCard = minionPlayedBoard.getCurrentPlayerCardHand(0);
+        def ret = theCard.useOn(CURRENT_PLAYER, target, copiedRoot, null, null);
+
+        expect:
+        assertFalse(ret == null);
+        assertEquals(ret.numChildren(), 7);
+
+        assertBoardDelta(startingBoard, minionPlayedBoard) {
+            currentPlayer {
+                playMinion(ElvenArcher)
+                mana(6)
+            }
+        }
+
+        HearthTreeNode child0 = ret.getChildren().get(0);
+        assertBoardDelta(minionPlayedBoard, child0.data_) {
+            currentPlayer {
+                heroHealth(29)
+            }
+        }
+
+        HearthTreeNode child1 = ret.getChildren().get(1);
+        assertBoardDelta(minionPlayedBoard, child1.data_) {
+            waitingPlayer {
+                heroHealth(29)
+            }
+        }
+
+        HearthTreeNode child2 = ret.getChildren().get(2);
+        assertBoardDelta(minionPlayedBoard, child2.data_) {
+            currentPlayer {
+                updateMinion(0, [deltaHealth: -1])
+            }
+        }
+
+        HearthTreeNode child3 = ret.getChildren().get(3);
+        assertBoardDelta(minionPlayedBoard, child3.data_) {
+            currentPlayer {
+                updateMinion(1, [deltaHealth: -1])
+            }
+        }
+
+        HearthTreeNode child4 = ret.getChildren().get(4);
+        assertBoardDelta(minionPlayedBoard, child4.data_) {
+            waitingPlayer {
+                updateMinion(0, [deltaHealth: -1])
+            }
+        }
+
+        HearthTreeNode child5 = ret.getChildren().get(5);
+        assertBoardDelta(minionPlayedBoard, child5.data_) {
+            waitingPlayer {
+                updateMinion(1, [deltaHealth: -1])
+            }
+        }
+
+        HearthTreeNode child6 = ret.getChildren().get(6);
+        assertBoardDelta(startingBoard, child6.data_) {
+            currentPlayer {
+                mana(6)
+                removeCardFromHand(ElvenArcher)
+                heroHealth(28)
+                updateMinion(0, [deltaHealth: -2])
+                updateMinion(1, [deltaHealth: -2])
+            }
+            waitingPlayer {
+                heroHealth(28)
+                removeMinion(2)
+                updateMinion(0, [deltaHealth: -2])
+                updateMinion(1, [deltaHealth: -2])
+            }
+        }
+    }
+
+}

--- a/src/test/groovy/com/hearthsim/test/helpers/BoardModelBuidlerSpec.groovy
+++ b/src/test/groovy/com/hearthsim/test/helpers/BoardModelBuidlerSpec.groovy
@@ -1,0 +1,119 @@
+package com.hearthsim.test.helpers
+
+import com.hearthsim.card.minion.concrete.ElvenArcher
+import com.hearthsim.model.BoardModel
+import com.hearthsim.model.PlayerSide
+import com.hearthsim.test.HearthBaseSpec
+
+import static com.hearthsim.model.PlayerSide.CURRENT_PLAYER
+import static com.hearthsim.model.PlayerSide.WAITING_PLAYER
+import static com.hearthsim.test.IsByteEqual.isByteEqual
+import static org.hamcrest.CoreMatchers.*
+import static spock.util.matcher.HamcrestSupport.expect
+
+class BoardModelBuidlerSpec extends HearthBaseSpec {
+
+    def "no-param building "() {
+        when:
+        BoardModel boardModel = new BoardModelBuilder().make {}
+
+        then:
+        expect boardModel, notNullValue()
+        expect boardModel.currentPlayer, notNullValue()
+        expect boardModel.waitingPlayer, notNullValue()
+        [CURRENT_PLAYER, WAITING_PLAYER].each { PlayerSide side ->
+            def playerModel = boardModel.modelForSide(side)
+            //todo: see if there is an 'isTrue' matcher. better yet one for collections
+            //todo: see if we want to use hamcrest at all...
+            assert playerModel.hero != null
+            assert playerModel.hero.armor == 0
+            assert playerModel.hero.weaponCharge == 0
+            assert playerModel.hero.health == 30
+
+            assert playerModel.deck == null
+            assert playerModel.hand.isEmpty()
+            assert playerModel.minions.isEmpty()
+            assert playerModel.overload == 0
+            assert playerModel.spellDamage == 0
+            assert playerModel.mana == 0
+            assert playerModel.mana == 0
+            assert boardModel.getFatigueDamage(side) == 1
+        }
+    }
+
+    def 'build field from map'() {
+        when:
+        BoardModel boardModel = new BoardModelBuilder().make {
+            currentPlayer {
+                field([
+                        [mana: 2, attack: 5, maxHealth: 3],
+                ])
+            }
+        }
+
+        then:
+        def currentPlayer = boardModel.getCurrentPlayer()
+        expect currentPlayer.minions.size(), is(1)
+
+        def firstMinion = currentPlayer.minions[0]
+        expect firstMinion.mana, isByteEqual(2)
+        expect firstMinion.attack, isByteEqual(5)
+        expect firstMinion.health, isByteEqual(3)
+        expect firstMinion.maxHealth, isByteEqual(3)
+        expect firstMinion.baseHealth, isByteEqual(3)
+    }
+
+    def 'build hand from class'() {
+        when:
+        BoardModel boardModel = new BoardModelBuilder().make {
+            currentPlayer {
+                hand([ElvenArcher])
+            }
+        }
+
+        then:
+        def currentPlayer = boardModel.getCurrentPlayer()
+        expect currentPlayer.hand.size(), equalTo(1)
+        expect currentPlayer.hand[0], isA(ElvenArcher)
+    }
+
+    def 'build hero attributes'() {
+        when:
+        BoardModel boardModel = new BoardModelBuilder().make {
+            currentPlayer {
+                mana(1)
+                fatigueDamage(1)
+                overload(1)
+                spellDamage(1)
+            }
+        }
+
+        then:
+        def currentPlayer = boardModel.modelForSide(CURRENT_PLAYER)
+        expect currentPlayer.mana, equalTo(1)
+        expect currentPlayer.maxMana, equalTo(1)
+        expect boardModel.getFatigueDamage(CURRENT_PLAYER), equalTo(1)
+
+        def playerModel = currentPlayer
+        expect playerModel.overload, isByteEqual(1)
+        expect playerModel.spellDamage, isByteEqual(1)
+    }
+
+    def 'build current and waiting player'() {
+        when:
+        BoardModel boardModel = new BoardModelBuilder().make {
+            currentPlayer {
+                fatigueDamage(1)
+            }
+            waitingPlayer {
+                fatigueDamage(2)
+            }
+        }
+
+        then:
+        expect boardModel.getFatigueDamage(CURRENT_PLAYER), equalTo(1)
+        expect boardModel.getFatigueDamage(WAITING_PLAYER), equalTo(2)
+    }
+
+
+}

--- a/src/test/groovy/com/hearthsim/test/helpers/BoardModelBuilder.groovy
+++ b/src/test/groovy/com/hearthsim/test/helpers/BoardModelBuilder.groovy
@@ -1,0 +1,136 @@
+package com.hearthsim.test.helpers
+
+import com.hearthsim.card.Card
+import com.hearthsim.card.minion.Minion
+import com.hearthsim.model.BoardModel
+import com.hearthsim.model.PlayerSide
+
+class BoardModelBuilder {
+
+    private BoardModel boardModel
+    private PlayerSide playerSide;
+
+    BoardModel make(Closure definition) {
+        if (!boardModel)
+            boardModel = new BoardModel()
+
+        runClosure definition
+
+        boardModel
+    }
+
+    private hand(List cardsInHand) {
+        // currently assuming it's a list of classes
+        cardsInHand.each { boardModel.placeCardHand(playerSide, it.newInstance()) }
+    }
+
+    private field(List field) {
+        field.each {
+            def mana = it.mana
+            def attack = it.attack
+            def maxHealth = it.maxHealth
+            def health
+            if (it.health) {
+                health = it.health
+            } else {
+                health = maxHealth
+            }
+
+            def minion
+            if (it.minion) {
+                minion = it.minion.newInstance()
+                minion.health = health
+            } else {
+                minion = new Minion("" + 0, (byte) mana, (byte) attack, (byte) health, (byte) attack, (byte) health, (byte) maxHealth)
+            }
+            boardModel.placeMinion(playerSide, minion);
+        }
+    }
+
+    private updateMinion(int position, Map options){
+        def minion = boardModel.getMinion(playerSide, position)
+        if (options.deltaHealth) {
+            minion.health += options.deltaHealth
+        }
+    }
+
+    private fatigueDamage(Number fatigueDamage) {
+        boardModel.setFatigueDamage(playerSide, (byte) fatigueDamage)
+    }
+
+    private overload(Number overload) {
+        boardModel.modelForSide(playerSide).overload = (byte) overload
+    }
+
+    private spellDamage(Number spellDamage) {
+        boardModel.modelForSide(playerSide).spellDamage = (byte) spellDamage
+    }
+
+    private heroHealth(Number health){
+        def side = boardModel.modelForSide(playerSide)
+        side.hero.health = health
+    }
+
+    private mana(Number mana) {
+        def model = boardModel.modelForSide(playerSide)
+        model.setMana((int) mana)
+        //todo: only do this if maxMana hasn't been set explicitly already
+        if (model.getMaxMana() == 0)
+            model.setMaxMana((int) mana)
+    }
+
+    private playMinion(Class<Minion> minionClass) {
+        removeCardFromHand(minionClass)
+        addMinionToField(minionClass)
+    }
+
+    private removeMinion(int index){
+        boardModel.removeMinion(playerSide, index)
+    }
+
+    private removeCardFromHand(Class card) {
+        def hand = boardModel.modelForSide(playerSide).hand
+        def cardInHand = hand.find { it.class == card }
+        boardModel.removeCardFromHand(cardInHand, playerSide)
+    }
+
+    private addMinionToField(Class<Minion> minionClass) {
+        Minion minion = minionClass.newInstance()
+        minion.hasAttacked(true)
+        minion.hasBeenUsed(true)
+        def numMinions = boardModel.modelForSide(playerSide).numMinions
+        // place the minion at the end by default
+        // todo: eventually this will need to be configurable
+        boardModel.placeMinion(playerSide, minion, numMinions)
+    }
+
+    private currentPlayer(Closure player) {
+        playerSide = PlayerSide.CURRENT_PLAYER
+
+        runClosure player
+    }
+
+    private waitingPlayer(Closure player) {
+        playerSide = PlayerSide.WAITING_PLAYER
+
+        runClosure player
+    }
+
+
+    private runClosure(Closure runClosure) {
+        // Create clone of closure for threading access.
+        Closure runClone = runClosure.clone()
+
+        // Set delegate of closure to this builder.
+        runClone.delegate = this
+
+        // And only use this builder as the closure delegate.
+        runClone.resolveStrategy = Closure.DELEGATE_ONLY
+
+        // Run closure code.
+        runClone()
+    }
+
+}
+
+

--- a/src/test/groovy/com/hearthsim/test/helpers/BoardModelMapBuilder.groovy
+++ b/src/test/groovy/com/hearthsim/test/helpers/BoardModelMapBuilder.groovy
@@ -1,0 +1,14 @@
+package com.hearthsim.test.helpers
+
+import com.hearthsim.model.BoardModel
+
+/**
+ * Created by kallin on 2014-09-18.
+ */
+class BoardModelMapBuilder {
+
+    public static BoardModel buildModel(Map args) {
+        return new BoardModel();
+    }
+
+}

--- a/src/test/java/com/hearthsim/test/minion/TestElvenArcher.java
+++ b/src/test/java/com/hearthsim/test/minion/TestElvenArcher.java
@@ -27,6 +27,7 @@ public class TestElvenArcher {
 	public void setup() throws HSException {
 		board = new HearthTreeNode(new BoardModel());
 
+        //public Minion(String name, byte mana, byte attack, byte health, byte baseAttack, byte baseHealth, byte maxHealth) {
 		Minion minion0_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);
 		Minion minion0_1 = new Minion("" + 0, mana, attack0, (byte)(health1 - 1), attack0, health1, health1);
 		Minion minion1_0 = new Minion("" + 0, mana, attack0, health0, attack0, health0, health0);


### PR DESCRIPTION
I've gone ahead and written a replacement for the TestElvenArcher test using [Spock](http://spock-framework.readthedocs.org/en/latest/introduction.html). You can ignore most of it, just look at ElvenArcherSpec, and see how that compares to TestElvenArcher. 

It's much more concise, and I think much more readable. I suggest that we port over all the card tests to this style.

I also suggest that we simplify these tests. I haven't gone through them all, but in this elven archer case it seems unnecessary to have so many minions on the board, esp. the Abomination. In fact, this card and something like rifleman should have the same test as they both just let you target for 1 damage. 

Let me know what you think!
